### PR TITLE
feat: TokenDataStore 에 updated_at 을 추가하여 토큰이 언제 만료되는지 확인할 수 있도록 처리

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -62,10 +62,12 @@ class MainActivity : AppCompatActivity() {
         when (this) {
             is UiState.Idle -> { }
             is UiState.Loading -> {
-                binding.includeProgressBar.root.isVisible = true
+                // TODO Not yet implemented
+//                binding.includeProgressBar.root.isVisible = true
             }
             is UiState.ShowPagingData -> {
-                binding.includeProgressBar.root.isVisible = false
+                // TODO Not yet implemented
+//                binding.includeProgressBar.root.isVisible = false
 
                 mainAdapter.submitData(this.repositories)
             }

--- a/data/src/main/java/com/prac/data/di/OkHttpClientModule.kt
+++ b/data/src/main/java/com/prac/data/di/OkHttpClientModule.kt
@@ -17,7 +17,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object OkHttpClientModule {
+internal object OkHttpClientModule {
     @Provides
     fun provideAuthorizationInterceptor(tokenDataStoreManager: TokenDataStoreManager) : Interceptor =
         AuthorizationInterceptor(tokenDataStoreManager)

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -80,13 +80,20 @@ class TokenDataStoreManager(
         }
     )
 
-    suspend fun saveTokenData(accessToken: String, refreshToken: String, accessTokenExpiresInMinute: Int, refreshTokenExpiresInMinute: Int) {
+    suspend fun saveTokenData(
+        accessToken: String,
+        refreshToken: String,
+        accessTokenExpiresInMinute: Int,
+        refreshTokenExpiresInMinute: Int,
+        accessTokenUpdatedAt: Long
+    ) {
         mContext.tokenDataStore.updateData { pref ->
             pref.toBuilder()
                 .setAccessToken(accessToken)
                 .setRefreshToken(refreshToken)
                 .setAccessTokenExpiresInMinute(accessTokenExpiresInMinute)
                 .setRefreshTokenExpiresInMinute(refreshTokenExpiresInMinute)
+                .setAccessTokenUpdatedAt(accessTokenUpdatedAt)
                 .build()
         }
     }

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -10,6 +10,7 @@ import androidx.datastore.migrations.SharedPreferencesMigration
 import androidx.datastore.migrations.SharedPreferencesView
 import com.google.protobuf.InvalidProtocolBufferException
 import com.prac.data.datastore.Token
+import com.prac.data.repository.model.TokenModel
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -80,20 +81,14 @@ internal class TokenDataStoreManager(
         }
     )
 
-    suspend fun saveTokenData(
-        accessToken: String,
-        refreshToken: String,
-        accessTokenExpiresInMinute: Int,
-        refreshTokenExpiresInMinute: Int,
-        accessTokenUpdatedAt: Long
-    ) {
+    suspend fun saveTokenData(token: TokenModel) {
         mContext.tokenDataStore.updateData { pref ->
             pref.toBuilder()
-                .setAccessToken(accessToken)
-                .setRefreshToken(refreshToken)
-                .setAccessTokenExpiresInMinute(accessTokenExpiresInMinute)
-                .setRefreshTokenExpiresInMinute(refreshTokenExpiresInMinute)
-                .setAccessTokenUpdatedAt(accessTokenUpdatedAt)
+                .setAccessToken(token.accessToken)
+                .setRefreshToken(token.refreshToken)
+                .setAccessTokenExpiresInMinute(token.expiresIn)
+                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresIn)
+                .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
         }
     }

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -10,13 +10,10 @@ import androidx.datastore.migrations.SharedPreferencesMigration
 import androidx.datastore.migrations.SharedPreferencesView
 import com.google.protobuf.InvalidProtocolBufferException
 import com.prac.data.datastore.Token
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import java.io.InputStream
 import java.io.OutputStream
 
-class TokenDataStoreManager(
+internal class TokenDataStoreManager(
     private val mContext: Context
 ) {
     companion object {
@@ -52,7 +49,10 @@ class TokenDataStoreManager(
                     context = context,
                     sharedPreferencesName = TOKEN_SHARED_PREFERENCES_NAME,
                     shouldRunMigration = {
-                        context.getSharedPreferences(TOKEN_SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE).all.any {
+                        context.getSharedPreferences(
+                            TOKEN_SHARED_PREFERENCES_NAME,
+                            Context.MODE_PRIVATE
+                        ).all.any {
                             it.value != null
                         }
                     }
@@ -64,7 +64,7 @@ class TokenDataStoreManager(
                         .build()
                 },
                 object : DataMigration<Token> {
-                    override suspend fun cleanUp() { }
+                    override suspend fun cleanUp() {}
 
                     override suspend fun shouldMigrate(currentData: Token): Boolean {
                         return currentData.isLoggedIn
@@ -98,35 +98,4 @@ class TokenDataStoreManager(
         }
     }
 
-    suspend fun getAccessToken() : String {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.accessToken
-            }.first()
-    }
-
-    suspend fun getRefreshToken() : String {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.refreshToken
-            }.first()
-    }
-
-    suspend fun getAccessTokenExpiresInMinute() : Int {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.accessTokenExpiresInMinute
-            }.first()
-    }
-
-    suspend fun getRefreshTokenExpiresInMinute() : Int {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.refreshTokenExpiresInMinute
-            }.first()
-    }
 }

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -86,8 +86,8 @@ internal class TokenDataStoreManager(
             pref.toBuilder()
                 .setAccessToken(token.accessToken)
                 .setRefreshToken(token.refreshToken)
-                .setAccessTokenExpiresInMinute(token.expiresIn)
-                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresIn)
+                .setAccessTokenExpiresInMinute(token.expiresInMinute)
+                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresInMinute)
                 .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
         }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.prac.data.repository.impl
 
 import com.prac.data.repository.TokenRepository
+import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.TokenApiDataSource
 import com.prac.data.source.TokenLocalDataSource
 import javax.inject.Inject
@@ -9,15 +10,10 @@ internal class TokenRepositoryImpl @Inject constructor(
     private val tokenLocalDataSource: TokenLocalDataSource,
     private val tokenApiDataSource: TokenApiDataSource
 ) : TokenRepository {
-    override suspend fun getTokenApi(
-        code: String
-    ): Result<Unit> {
+    override suspend fun getTokenApi(code: String): Result<Unit> {
         try {
-            val model = tokenApiDataSource.getToken(
-                code = code
-            )
-
-            setToken(model.accessToken, model.refreshToken)
+            val model = tokenApiDataSource.getToken(code)
+            setToken(model)
 
             return Result.success(Unit)
         } catch (e: Exception) {
@@ -29,7 +25,7 @@ internal class TokenRepositoryImpl @Inject constructor(
         return tokenLocalDataSource.isLoggedIn()
     }
 
-    private suspend fun setToken(accessToken: String, refreshToken: String) {
-        tokenLocalDataSource.setToken(accessToken, refreshToken)
+    private suspend fun setToken(token: TokenModel) {
+        tokenLocalDataSource.setToken(token)
     }
 }

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -2,5 +2,7 @@ package com.prac.data.repository.model
 
 internal data class TokenModel(
     val accessToken: String,
-    val refreshToken: String
+    val refreshToken: String,
+    val expiresIn: Int,
+    val refreshTokenExpiresIn: Int
 )

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -1,8 +1,11 @@
 package com.prac.data.repository.model
 
+import java.time.ZonedDateTime
+
 internal data class TokenModel(
     val accessToken: String,
     val refreshToken: String,
     val expiresIn: Int,
-    val refreshTokenExpiresIn: Int
+    val refreshTokenExpiresIn: Int,
+    val updatedAt: ZonedDateTime
 )

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -5,13 +5,13 @@ import java.time.ZonedDateTime
 internal data class TokenModel(
     val accessToken: String,
     val refreshToken: String,
-    val expiresIn: Int,
-    val refreshTokenExpiresIn: Int,
+    val expiresInMinute: Int,
+    val refreshTokenExpiresInMinute: Int,
     val updatedAt: ZonedDateTime
 ) {
     val isExpired: Boolean
-        get() = updatedAt.plusSeconds(expiresIn.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusMinutes(expiresInMinute.toLong()).isBefore(ZonedDateTime.now())
 
     val isRefreshTokenExpired: Boolean
-        get() = updatedAt.plusSeconds(refreshTokenExpiresIn.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusMinutes(refreshTokenExpiresInMinute.toLong()).isBefore(ZonedDateTime.now())
 }

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -8,4 +8,10 @@ internal data class TokenModel(
     val expiresIn: Int,
     val refreshTokenExpiresIn: Int,
     val updatedAt: ZonedDateTime
-)
+) {
+    val isExpired: Boolean
+        get() = updatedAt.plusSeconds(expiresIn.toLong()).isBefore(ZonedDateTime.now())
+
+    val isRefreshTokenExpired: Boolean
+        get() = updatedAt.plusSeconds(refreshTokenExpiresIn.toLong()).isBefore(ZonedDateTime.now())
+}

--- a/data/src/main/java/com/prac/data/source/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/TokenLocalDataSource.kt
@@ -1,10 +1,9 @@
 package com.prac.data.source
 
+import com.prac.data.repository.model.TokenModel
+
 internal interface TokenLocalDataSource {
-    suspend fun setToken(
-        accessToken: String,
-        refreshToken: String
-    )
+    suspend fun setToken(token: TokenModel)
 
     suspend fun isLoggedIn() : Boolean
 }

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -16,13 +16,11 @@ class AuthorizationInterceptor @Inject constructor(
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request().putTokenHeader()
+        val accessToken = "" // TODO run blocking to get access token
+        val request = chain.request().newBuilder()
+            .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
+            .build()
         return chain.proceed(request)
     }
 
-    private fun Request.putTokenHeader(accessToken: String) : Request {
-        return this.newBuilder()
-            .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
-            .build()
-    }
 }

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -7,7 +7,7 @@ import okhttp3.Request
 import okhttp3.Response
 import javax.inject.Inject
 
-class AuthorizationInterceptor @Inject constructor(
+internal class AuthorizationInterceptor @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : Interceptor {
     companion object {

--- a/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
@@ -19,8 +19,8 @@ internal class TokenApiDataSourceImpl @Inject constructor(
         return TokenModel(
             accessToken = response.accessToken,
             refreshToken = response.refreshToken,
-            expiresIn = response.expiresIn,
-            refreshTokenExpiresIn = response.refreshTokenExpiresIn,
+            expiresInMinute = response.expiresIn,
+            refreshTokenExpiresInMinute = response.refreshTokenExpiresIn,
             updatedAt = ZonedDateTime.now()
         )
     }

--- a/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.prac.data.source.impl
 import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.TokenApiDataSource
 import com.prac.data.source.api.GitHubTokenApi
+import java.time.ZonedDateTime
 import javax.inject.Inject
 
 internal class TokenApiDataSourceImpl @Inject constructor(
@@ -19,7 +20,8 @@ internal class TokenApiDataSourceImpl @Inject constructor(
             accessToken = response.accessToken,
             refreshToken = response.refreshToken,
             expiresIn = response.expiresIn,
-            refreshTokenExpiresIn = response.refreshTokenExpiresIn
+            refreshTokenExpiresIn = response.refreshTokenExpiresIn,
+            updatedAt = ZonedDateTime.now()
         )
     }
 }

--- a/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
@@ -17,7 +17,9 @@ internal class TokenApiDataSourceImpl @Inject constructor(
 
         return TokenModel(
             accessToken = response.accessToken,
-            refreshToken = response.refreshToken
+            refreshToken = response.refreshToken,
+            expiresIn = response.expiresIn,
+            refreshTokenExpiresIn = response.refreshTokenExpiresIn
         )
     }
 }

--- a/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
@@ -1,14 +1,15 @@
 package com.prac.data.source.impl
 
 import com.prac.data.di.datastore.TokenDataStoreManager
+import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.TokenLocalDataSource
 import javax.inject.Inject
 
 internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
-    override suspend fun setToken(accessToken: String, refreshToken: String) {
-        // TODO save token to local data store
+    override suspend fun setToken(token: TokenModel) {
+        tokenDataStoreManager.saveTokenData(token)
     }
 
     override suspend fun isLoggedIn(): Boolean {

--- a/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
@@ -8,12 +8,10 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
     override suspend fun setToken(accessToken: String, refreshToken: String) {
-        tokenDataStoreManager.apply {
-            putToken(accessToken, refreshToken)
-        }
+        // TODO save token to local data store
     }
 
     override suspend fun isLoggedIn(): Boolean {
-        return tokenDataStoreManager.isLoggedIn()
+        TODO("Not yet implemented")
     }
 }

--- a/data/src/main/proto/token.proto
+++ b/data/src/main/proto/token.proto
@@ -9,4 +9,5 @@ message Token {
   bool is_logged_in = 3 [deprecated = true];
   int32 access_token_expires_in_minute = 4;
   int32 refresh_token_expires_in_minute = 5;
+  int64 access_token_updated_at = 6;
 }


### PR DESCRIPTION
notion - https://www.notion.so/Token-data-store-updated-time-b2210ef1d20244f1b53726d1e98c88ed

# AS-IS
- token.proto 에 아래와 같은 사항이 저장되어있음
```protobuf
message Token {
  string access_token = 1;
  string refresh_token = 2;
  bool is_logged_in = 3 [deprecated = true];
  int32 access_token_expires_in_minute = 4;
  int32 refresh_token_expires_in_minute = 5;
}
```
- 이 때 expires_in_minute 만 존재하면 언제 만료되는지 알 수 없음

# 작업사항
- token.proto 에 updated_at 필드를 추가
- TokenModel 에 expiresIn, refreshTokenExpiresIn, updatedAt 필드 추가

# TO-BE
- #43