### PR TITLE
refactor: AccessToken 의 저장 로직을 변경하고 AuthorizationInterceptor 에 bearer token 추가

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -62,10 +62,12 @@ class MainActivity : AppCompatActivity() {
         when (this) {
             is UiState.Idle -> { }
             is UiState.Loading -> {
-                binding.includeProgressBar.root.isVisible = true
+                // TODO Not yet implemented
+//                binding.includeProgressBar.root.isVisible = true
             }
             is UiState.ShowPagingData -> {
-                binding.includeProgressBar.root.isVisible = false
+                // TODO Not yet implemented
+//                binding.includeProgressBar.root.isVisible = false
 
                 mainAdapter.submitData(this.repositories)
             }

--- a/data/src/main/java/com/prac/data/di/OkHttpClientModule.kt
+++ b/data/src/main/java/com/prac/data/di/OkHttpClientModule.kt
@@ -17,7 +17,7 @@ import javax.inject.Singleton
 
 @Module
 @InstallIn(SingletonComponent::class)
-object OkHttpClientModule {
+internal object OkHttpClientModule {
     @Provides
     fun provideAuthorizationInterceptor(tokenDataStoreManager: TokenDataStoreManager) : Interceptor =
         AuthorizationInterceptor(tokenDataStoreManager)

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -11,8 +11,11 @@ import androidx.datastore.migrations.SharedPreferencesView
 import com.google.protobuf.InvalidProtocolBufferException
 import com.prac.data.datastore.Token
 import com.prac.data.repository.model.TokenModel
+import kotlinx.coroutines.flow.first
 import java.io.InputStream
 import java.io.OutputStream
+import java.time.Instant
+import java.time.ZoneId
 
 internal class TokenDataStoreManager(
     private val mContext: Context
@@ -90,6 +93,18 @@ internal class TokenDataStoreManager(
                 .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresInMinute)
                 .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
+        }
+    }
+
+    suspend fun getToken(): TokenModel {
+        return mContext.tokenDataStore.data.first().let {
+            TokenModel(
+                accessToken = it.accessToken,
+                refreshToken = it.refreshToken,
+                expiresInMinute = it.accessTokenExpiresInMinute,
+                refreshTokenExpiresInMinute = it.refreshTokenExpiresInMinute,
+                updatedAt = Instant.ofEpochMilli(it.accessTokenUpdatedAt).atZone(ZoneId.systemDefault())
+            )
         }
     }
 

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -80,13 +80,20 @@ class TokenDataStoreManager(
         }
     )
 
-    suspend fun saveTokenData(accessToken: String, refreshToken: String, accessTokenExpiresInMinute: Int, refreshTokenExpiresInMinute: Int) {
+    suspend fun saveTokenData(
+        accessToken: String,
+        refreshToken: String,
+        accessTokenExpiresInMinute: Int,
+        refreshTokenExpiresInMinute: Int,
+        accessTokenUpdatedAt: Long
+    ) {
         mContext.tokenDataStore.updateData { pref ->
             pref.toBuilder()
                 .setAccessToken(accessToken)
                 .setRefreshToken(refreshToken)
                 .setAccessTokenExpiresInMinute(accessTokenExpiresInMinute)
                 .setRefreshTokenExpiresInMinute(refreshTokenExpiresInMinute)
+                .setAccessTokenUpdatedAt(accessTokenUpdatedAt)
                 .build()
         }
     }

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -10,6 +10,7 @@ import androidx.datastore.migrations.SharedPreferencesMigration
 import androidx.datastore.migrations.SharedPreferencesView
 import com.google.protobuf.InvalidProtocolBufferException
 import com.prac.data.datastore.Token
+import com.prac.data.repository.model.TokenModel
 import java.io.InputStream
 import java.io.OutputStream
 
@@ -80,20 +81,14 @@ internal class TokenDataStoreManager(
         }
     )
 
-    suspend fun saveTokenData(
-        accessToken: String,
-        refreshToken: String,
-        accessTokenExpiresInMinute: Int,
-        refreshTokenExpiresInMinute: Int,
-        accessTokenUpdatedAt: Long
-    ) {
+    suspend fun saveTokenData(token: TokenModel) {
         mContext.tokenDataStore.updateData { pref ->
             pref.toBuilder()
-                .setAccessToken(accessToken)
-                .setRefreshToken(refreshToken)
-                .setAccessTokenExpiresInMinute(accessTokenExpiresInMinute)
-                .setRefreshTokenExpiresInMinute(refreshTokenExpiresInMinute)
-                .setAccessTokenUpdatedAt(accessTokenUpdatedAt)
+                .setAccessToken(token.accessToken)
+                .setRefreshToken(token.refreshToken)
+                .setAccessTokenExpiresInMinute(token.expiresIn)
+                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresIn)
+                .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
         }
     }

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -10,13 +10,10 @@ import androidx.datastore.migrations.SharedPreferencesMigration
 import androidx.datastore.migrations.SharedPreferencesView
 import com.google.protobuf.InvalidProtocolBufferException
 import com.prac.data.datastore.Token
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.map
 import java.io.InputStream
 import java.io.OutputStream
 
-class TokenDataStoreManager(
+internal class TokenDataStoreManager(
     private val mContext: Context
 ) {
     companion object {
@@ -52,7 +49,10 @@ class TokenDataStoreManager(
                     context = context,
                     sharedPreferencesName = TOKEN_SHARED_PREFERENCES_NAME,
                     shouldRunMigration = {
-                        context.getSharedPreferences(TOKEN_SHARED_PREFERENCES_NAME, Context.MODE_PRIVATE).all.any {
+                        context.getSharedPreferences(
+                            TOKEN_SHARED_PREFERENCES_NAME,
+                            Context.MODE_PRIVATE
+                        ).all.any {
                             it.value != null
                         }
                     }
@@ -64,7 +64,7 @@ class TokenDataStoreManager(
                         .build()
                 },
                 object : DataMigration<Token> {
-                    override suspend fun cleanUp() { }
+                    override suspend fun cleanUp() {}
 
                     override suspend fun shouldMigrate(currentData: Token): Boolean {
                         return currentData.isLoggedIn
@@ -98,35 +98,4 @@ class TokenDataStoreManager(
         }
     }
 
-    suspend fun getAccessToken() : String {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.accessToken
-            }.first()
-    }
-
-    suspend fun getRefreshToken() : String {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.refreshToken
-            }.first()
-    }
-
-    suspend fun getAccessTokenExpiresInMinute() : Int {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.accessTokenExpiresInMinute
-            }.first()
-    }
-
-    suspend fun getRefreshTokenExpiresInMinute() : Int {
-        return mContext.tokenDataStore.data
-            .catch { emit(Token.getDefaultInstance()) }
-            .map {
-                it.refreshTokenExpiresInMinute
-            }.first()
-    }
 }

--- a/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
+++ b/data/src/main/java/com/prac/data/di/datastore/TokenDataStoreManager.kt
@@ -86,8 +86,8 @@ internal class TokenDataStoreManager(
             pref.toBuilder()
                 .setAccessToken(token.accessToken)
                 .setRefreshToken(token.refreshToken)
-                .setAccessTokenExpiresInMinute(token.expiresIn)
-                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresIn)
+                .setAccessTokenExpiresInMinute(token.expiresInMinute)
+                .setRefreshTokenExpiresInMinute(token.refreshTokenExpiresInMinute)
                 .setAccessTokenUpdatedAt(token.updatedAt.toInstant().toEpochMilli())
                 .build()
         }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.prac.data.repository.impl
 
 import com.prac.data.repository.TokenRepository
+import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.TokenApiDataSource
 import com.prac.data.source.TokenLocalDataSource
 import javax.inject.Inject
@@ -9,15 +10,10 @@ internal class TokenRepositoryImpl @Inject constructor(
     private val tokenLocalDataSource: TokenLocalDataSource,
     private val tokenApiDataSource: TokenApiDataSource
 ) : TokenRepository {
-    override suspend fun getTokenApi(
-        code: String
-    ): Result<Unit> {
+    override suspend fun getTokenApi(code: String): Result<Unit> {
         try {
-            val model = tokenApiDataSource.getToken(
-                code = code
-            )
-
-            setToken(model.accessToken, model.refreshToken)
+            val model = tokenApiDataSource.getToken(code)
+            setToken(model)
 
             return Result.success(Unit)
         } catch (e: Exception) {
@@ -29,7 +25,7 @@ internal class TokenRepositoryImpl @Inject constructor(
         return tokenLocalDataSource.isLoggedIn()
     }
 
-    private suspend fun setToken(accessToken: String, refreshToken: String) {
-        tokenLocalDataSource.setToken(accessToken, refreshToken)
+    private suspend fun setToken(token: TokenModel) {
+        tokenLocalDataSource.setToken(token)
     }
 }

--- a/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/TokenRepositoryImpl.kt
@@ -22,7 +22,8 @@ internal class TokenRepositoryImpl @Inject constructor(
     }
 
     override suspend fun isLoggedIn(): Boolean {
-        return tokenLocalDataSource.isLoggedIn()
+        val token = tokenLocalDataSource.getToken()
+        return token.accessToken.isNotEmpty()
     }
 
     private suspend fun setToken(token: TokenModel) {

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -2,5 +2,7 @@ package com.prac.data.repository.model
 
 internal data class TokenModel(
     val accessToken: String,
-    val refreshToken: String
+    val refreshToken: String,
+    val expiresIn: Int,
+    val refreshTokenExpiresIn: Int
 )

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -1,8 +1,11 @@
 package com.prac.data.repository.model
 
+import java.time.ZonedDateTime
+
 internal data class TokenModel(
     val accessToken: String,
     val refreshToken: String,
     val expiresIn: Int,
-    val refreshTokenExpiresIn: Int
+    val refreshTokenExpiresIn: Int,
+    val updatedAt: ZonedDateTime
 )

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -5,13 +5,13 @@ import java.time.ZonedDateTime
 internal data class TokenModel(
     val accessToken: String,
     val refreshToken: String,
-    val expiresIn: Int,
-    val refreshTokenExpiresIn: Int,
+    val expiresInMinute: Int,
+    val refreshTokenExpiresInMinute: Int,
     val updatedAt: ZonedDateTime
 ) {
     val isExpired: Boolean
-        get() = updatedAt.plusSeconds(expiresIn.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusMinutes(expiresInMinute.toLong()).isBefore(ZonedDateTime.now())
 
     val isRefreshTokenExpired: Boolean
-        get() = updatedAt.plusSeconds(refreshTokenExpiresIn.toLong()).isBefore(ZonedDateTime.now())
+        get() = updatedAt.plusMinutes(refreshTokenExpiresInMinute.toLong()).isBefore(ZonedDateTime.now())
 }

--- a/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/TokenModel.kt
@@ -8,4 +8,10 @@ internal data class TokenModel(
     val expiresIn: Int,
     val refreshTokenExpiresIn: Int,
     val updatedAt: ZonedDateTime
-)
+) {
+    val isExpired: Boolean
+        get() = updatedAt.plusSeconds(expiresIn.toLong()).isBefore(ZonedDateTime.now())
+
+    val isRefreshTokenExpired: Boolean
+        get() = updatedAt.plusSeconds(refreshTokenExpiresIn.toLong()).isBefore(ZonedDateTime.now())
+}

--- a/data/src/main/java/com/prac/data/source/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/TokenLocalDataSource.kt
@@ -5,5 +5,5 @@ import com.prac.data.repository.model.TokenModel
 internal interface TokenLocalDataSource {
     suspend fun setToken(token: TokenModel)
 
-    suspend fun isLoggedIn() : Boolean
+    suspend fun getToken(): TokenModel
 }

--- a/data/src/main/java/com/prac/data/source/TokenLocalDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/TokenLocalDataSource.kt
@@ -1,10 +1,9 @@
 package com.prac.data.source
 
+import com.prac.data.repository.model.TokenModel
+
 internal interface TokenLocalDataSource {
-    suspend fun setToken(
-        accessToken: String,
-        refreshToken: String
-    )
+    suspend fun setToken(token: TokenModel)
 
     suspend fun isLoggedIn() : Boolean
 }

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -12,10 +12,20 @@ internal class AuthorizationInterceptor @Inject constructor(
     companion object {
         private const val AUTHORIZATION = "Authorization"
         private const val AUTHORIZATION_TYPE = "Bearer"
+
+        private val UNAUTHORIZED = Response.Builder()
+            .code(401)
+            .message("Unauthorized")
+            .build()
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val accessToken = runBlocking { tokenDataStoreManager.getToken() }
+        if (accessToken.isExpired) {
+            // TODO refresh access token by refresh token
+            // 하지만 refresh 로직은 따로 구현하는 것으로 하고 여기서는 401을 리턴한다.
+            return UNAUTHORIZED
+        }
         val request = chain.request().newBuilder()
             .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
             .build()

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -3,7 +3,6 @@ package com.prac.data.source.api
 import com.prac.data.di.datastore.TokenDataStoreManager
 import kotlinx.coroutines.runBlocking
 import okhttp3.Interceptor
-import okhttp3.Request
 import okhttp3.Response
 import javax.inject.Inject
 
@@ -16,7 +15,7 @@ internal class AuthorizationInterceptor @Inject constructor(
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val accessToken = "" // TODO run blocking to get access token
+        val accessToken = runBlocking { tokenDataStoreManager.getToken() }
         val request = chain.request().newBuilder()
             .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
             .build()

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -16,13 +16,11 @@ class AuthorizationInterceptor @Inject constructor(
     }
 
     override fun intercept(chain: Interceptor.Chain): Response {
-        val request = chain.request().putTokenHeader()
+        val accessToken = "" // TODO run blocking to get access token
+        val request = chain.request().newBuilder()
+            .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
+            .build()
         return chain.proceed(request)
     }
 
-    private fun Request.putTokenHeader(accessToken: String) : Request {
-        return this.newBuilder()
-            .addHeader(AUTHORIZATION, "$AUTHORIZATION_TYPE $accessToken")
-            .build()
-    }
 }

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -7,7 +7,7 @@ import okhttp3.Request
 import okhttp3.Response
 import javax.inject.Inject
 
-class AuthorizationInterceptor @Inject constructor(
+internal class AuthorizationInterceptor @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : Interceptor {
     companion object {

--- a/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
+++ b/data/src/main/java/com/prac/data/source/api/AuthorizationInterceptor.kt
@@ -9,15 +9,6 @@ import javax.inject.Inject
 internal class AuthorizationInterceptor @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : Interceptor {
-    companion object {
-        private const val AUTHORIZATION = "Authorization"
-        private const val AUTHORIZATION_TYPE = "Bearer"
-
-        private val UNAUTHORIZED = Response.Builder()
-            .code(401)
-            .message("Unauthorized")
-            .build()
-    }
 
     override fun intercept(chain: Interceptor.Chain): Response {
         val accessToken = runBlocking { tokenDataStoreManager.getToken() }
@@ -32,4 +23,13 @@ internal class AuthorizationInterceptor @Inject constructor(
         return chain.proceed(request)
     }
 
+    companion object {
+        private const val AUTHORIZATION = "Authorization"
+        private const val AUTHORIZATION_TYPE = "Bearer"
+
+        private val UNAUTHORIZED = Response.Builder()
+            .code(401)
+            .message("Unauthorized")
+            .build()
+    }
 }

--- a/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
@@ -19,8 +19,8 @@ internal class TokenApiDataSourceImpl @Inject constructor(
         return TokenModel(
             accessToken = response.accessToken,
             refreshToken = response.refreshToken,
-            expiresIn = response.expiresIn,
-            refreshTokenExpiresIn = response.refreshTokenExpiresIn,
+            expiresInMinute = response.expiresIn,
+            refreshTokenExpiresInMinute = response.refreshTokenExpiresIn,
             updatedAt = ZonedDateTime.now()
         )
     }

--- a/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
@@ -3,6 +3,7 @@ package com.prac.data.source.impl
 import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.TokenApiDataSource
 import com.prac.data.source.api.GitHubTokenApi
+import java.time.ZonedDateTime
 import javax.inject.Inject
 
 internal class TokenApiDataSourceImpl @Inject constructor(
@@ -19,7 +20,8 @@ internal class TokenApiDataSourceImpl @Inject constructor(
             accessToken = response.accessToken,
             refreshToken = response.refreshToken,
             expiresIn = response.expiresIn,
-            refreshTokenExpiresIn = response.refreshTokenExpiresIn
+            refreshTokenExpiresIn = response.refreshTokenExpiresIn,
+            updatedAt = ZonedDateTime.now()
         )
     }
 }

--- a/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenApiDataSourceImpl.kt
@@ -17,7 +17,9 @@ internal class TokenApiDataSourceImpl @Inject constructor(
 
         return TokenModel(
             accessToken = response.accessToken,
-            refreshToken = response.refreshToken
+            refreshToken = response.refreshToken,
+            expiresIn = response.expiresIn,
+            refreshTokenExpiresIn = response.refreshTokenExpiresIn
         )
     }
 }

--- a/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
@@ -12,7 +12,7 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
         tokenDataStoreManager.saveTokenData(token)
     }
 
-    override suspend fun isLoggedIn(): Boolean {
-        TODO("Not yet implemented")
+    override suspend fun getToken(): TokenModel {
+        return tokenDataStoreManager.getToken()
     }
 }

--- a/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
@@ -1,14 +1,15 @@
 package com.prac.data.source.impl
 
 import com.prac.data.di.datastore.TokenDataStoreManager
+import com.prac.data.repository.model.TokenModel
 import com.prac.data.source.TokenLocalDataSource
 import javax.inject.Inject
 
 internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
-    override suspend fun setToken(accessToken: String, refreshToken: String) {
-        // TODO save token to local data store
+    override suspend fun setToken(token: TokenModel) {
+        tokenDataStoreManager.saveTokenData(token)
     }
 
     override suspend fun isLoggedIn(): Boolean {

--- a/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/TokenLocalDataSourceImpl.kt
@@ -8,12 +8,10 @@ internal class TokenLocalDataSourceImpl @Inject constructor(
     private val tokenDataStoreManager: TokenDataStoreManager
 ) : TokenLocalDataSource {
     override suspend fun setToken(accessToken: String, refreshToken: String) {
-        tokenDataStoreManager.apply {
-            putToken(accessToken, refreshToken)
-        }
+        // TODO save token to local data store
     }
 
     override suspend fun isLoggedIn(): Boolean {
-        return tokenDataStoreManager.isLoggedIn()
+        TODO("Not yet implemented")
     }
 }

--- a/data/src/main/proto/token.proto
+++ b/data/src/main/proto/token.proto
@@ -9,4 +9,5 @@ message Token {
   bool is_logged_in = 3 [deprecated = true];
   int32 access_token_expires_in_minute = 4;
   int32 refresh_token_expires_in_minute = 5;
+  int64 access_token_updated_at = 6;
 }


### PR DESCRIPTION
notion - https://www.notion.so/AccessToken-2a0532e239b14a579d4cb6d3cf8c1cac

# AS-IS
- TokenRepository → TokenLocalDataSource → TokenDataStore 를 통해서 현재 access token, refresh token 을 저장하고, 저장된 토큰을 불러오고 있음
- 이 때 토큰을 불러올 때 token 정보를 확인하기 힘든 구조
# 작업사항
![스크린샷 2024-08-06 오전 4 20 10](https://github.com/user-attachments/assets/1a2c0924-b749-4713-b744-684f5b595a82)
