### PR TITLE
feat: refact repo data class

### DIFF
--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -4,6 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.RepoApiDataSource
@@ -25,7 +26,7 @@ internal class RepoRepositoryImpl @Inject constructor(
         ).flow
             .map { pagingData ->
                 pagingData.map { repoModel ->
-                    repoModel.toEntity()
+                    RepoEntity(repoModel.id, repoModel.name, OwnerEntity(repoModel.owner.login, repoModel.owner.avatarUrl), repoModel.stargazersCount, repoModel.updatedAt)
                 }
             }
 }

--- a/data/src/main/java/com/prac/data/repository/model/OwnerModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/OwnerModel.kt
@@ -1,11 +1,6 @@
 package com.prac.data.repository.model
 
-import com.prac.data.entity.OwnerEntity
-
 internal data class OwnerModel(
     val login: String,
     val avatarUrl: String
-) {
-    fun toEntity() =
-        OwnerEntity(login, avatarUrl)
-}
+)

--- a/data/src/main/java/com/prac/data/repository/model/RepoModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/RepoModel.kt
@@ -1,14 +1,9 @@
 package com.prac.data.repository.model
 
-import com.prac.data.entity.RepoEntity
-
 internal data class RepoModel(
     val id: Int,
     val name: String,
     val owner: OwnerModel,
     val stargazersCount: Int,
     val updatedAt: String
-) {
-    fun toEntity() =
-        RepoEntity(id, name, owner.toEntity(), stargazersCount, updatedAt)
-}
+)

--- a/data/src/main/java/com/prac/data/source/dto/OwnerDto.kt
+++ b/data/src/main/java/com/prac/data/source/dto/OwnerDto.kt
@@ -1,6 +1,5 @@
 package com.prac.data.source.dto
 
-import com.prac.data.repository.model.OwnerModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,7 +7,4 @@ import kotlinx.serialization.Serializable
 internal data class OwnerDto(
     @SerialName("login") val login: String = "",
     @SerialName("avatar_url") val avatarUrl: String = ""
-) {
-    fun toModel() =
-        OwnerModel(login, avatarUrl)
-}
+)

--- a/data/src/main/java/com/prac/data/source/dto/RepoDto.kt
+++ b/data/src/main/java/com/prac/data/source/dto/RepoDto.kt
@@ -1,6 +1,5 @@
 package com.prac.data.source.dto
 
-import com.prac.data.repository.model.RepoModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,4 @@ internal data class RepoDto(
     @SerialName("owner") val owner: OwnerDto = OwnerDto(),
     @SerialName("stargazers_count") val stargazersCount: Int = 0,
     @SerialName("updated_at") val updatedAt: String = ""
-) {
-    fun toModel() =
-        RepoModel(id, name, owner.toModel(), stargazersCount, updatedAt)
-}
+)

--- a/data/src/main/java/com/prac/data/source/impl/RepoApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoApiDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.prac.data.source.impl
 
 import androidx.paging.PagingState
+import com.prac.data.repository.model.OwnerModel
 import com.prac.data.repository.model.RepoModel
 import com.prac.data.source.RepoApiDataSource
 import com.prac.data.source.api.GitHubApi
@@ -27,7 +28,9 @@ internal class RepoApiDataSourceImpl @Inject constructor(
             }
 
             return LoadResult.Page(
-                data = response.map { it.toModel() },
+                data = response.map {
+                    RepoModel(it.id, it.name, OwnerModel(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt)
+                },
                 prevKey = if (position == STARTING_PAGE_INDEX) null else position - 1,
                 nextKey = nextKey
             )


### PR DESCRIPTION
notion - https://www.notion.so/feat-refact-repo-data-class-d78e606918fc4ef29803f579c84488ef?pvs=4

## AS-IS
 - 기존에 존재하는 toModel, toEntity 메서드는 클린 아키텍쳐 관점에서 잘못된 메서드이다.

## 작업 사항
 - toModel, toEntity 메서드를 제거하고 데이터를 변환할 때 data class 생성자를 통해서 변환한다.

## TO-BE
 - 