### PR TITLE
feat:  refact repo data class 

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -76,4 +76,8 @@ class MainViewModel @Inject constructor(
             _jobSparseArray[position] = null
         }
     }
+
+    fun cancelJob(position: Int) {
+        if (_jobSparseArray[position].isActive) _jobSparseArray[position].cancel()
+    }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -55,14 +55,8 @@ class MainViewModel @Inject constructor(
     }
 
     fun updateIsStarred(id: Int, isStarred: Boolean) {
-        _uiState.update {
-            UiState.ShowPagingData(
-                (it as UiState.ShowPagingData).repositories
-                    .map { repoEntity ->
-                        if (repoEntity.id == id) repoEntity.copy(isStarred = isStarred)
-                        else repoEntity
-                    }
-            )
+        viewModelScope.launch {
+            _isStarredUpdate.emit(Pair(id, isStarred))
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -44,7 +44,7 @@ class MainViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
 
-    private val _isStarredUpdate = MutableStateFlow<List<Pair<Int, Boolean>>>(emptyList())
+    private val _isStarredList = MutableStateFlow<List<Pair<Int, Boolean>>>(emptyList())
 
     private fun getRepositories() {
         viewModelScope.launch {
@@ -52,8 +52,8 @@ class MainViewModel @Inject constructor(
 
             combine(
                 repoRepository.getRepositories().cachedIn(viewModelScope),
-                _isStarredUpdate
-                ) { pagingData, starredMap ->
+                _isStarredList
+                ) { pagingData, isStarredList ->
 
             }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -1,5 +1,6 @@
 package com.prac.githubrepo.main
 
+import android.util.SparseArray
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
@@ -8,6 +9,7 @@ import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.GitHubApiException
 import com.prac.data.repository.RepoRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
@@ -34,6 +36,8 @@ class MainViewModel @Inject constructor(
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
+
+    private val _jobSparseArray = SparseArray<Job>()
 
     fun getRepositories() {
         viewModelScope.launch {

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -58,8 +58,4 @@ class MainViewModel @Inject constructor(
             }
         }
     }
-
-    fun cancelJob(position: Int) {
-        if (_jobSparseArray[position].isActive) _jobSparseArray[position].cancel()
-    }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
 import androidx.paging.PagingData
+import androidx.paging.cachedIn
 import androidx.paging.map
 import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.GitHubApiException
@@ -45,7 +46,7 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch {
             if (_uiState.value != UiState.Idle) return@launch
 
-            repoRepository.getRepositories().collect { pagingData ->
+            repoRepository.getRepositories().cachedIn(viewModelScope).collect { pagingData ->
                 _uiState.update { UiState.ShowPagingData(pagingData) }
             }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -10,7 +10,9 @@ import com.prac.data.exception.GitHubApiException
 import com.prac.data.repository.RepoRepository
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -30,12 +32,19 @@ class MainViewModel @Inject constructor(
         ) : UiState()
     }
 
+    sealed class Event {
+        data class StartIsStarredUpdate(val position: Int, val isStarred: Boolean) : Event()
+    }
+
     init {
         getRepositories()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
+
+    private val _event = MutableSharedFlow<Event>()
+    val event = _event.asSharedFlow()
 
     private val _jobSparseArray = SparseArray<Job>()
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -42,6 +42,8 @@ class MainViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
 
+    private val _isStarredUpdate = MutableSharedFlow<Pair<Int, Boolean>>()
+
     private fun getRepositories() {
         viewModelScope.launch {
             if (_uiState.value != UiState.Idle) return@launch

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -60,8 +60,8 @@ class MainViewModel @Inject constructor(
     }
 
     fun updateIsStarred(id: Int, isStarred: Boolean) {
-        viewModelScope.launch {
-
+        _isStarredList.update {
+            it + Pair(id, isStarred)
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -47,8 +47,6 @@ class MainViewModel @Inject constructor(
     private val _event = MutableSharedFlow<Event>()
     val event = _event.asSharedFlow()
 
-    private val _jobSparseArray = SparseArray<Job>()
-
     private fun getRepositories() {
         viewModelScope.launch {
             if (_uiState.value != UiState.Idle) return@launch

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -59,24 +59,6 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun putAndStartJob(position: Int, repoName: String) {
-        viewModelScope.launch {
-            _jobSparseArray[position] = launch(Dispatchers.IO) {
-                val result = repoRepository.checkRepositoryIsStarred(repoName)
-
-                result.onSuccess {
-                    _event.emit(Event.StartIsStarredUpdate(position, it))
-                }.onFailure {
-                    _event.emit(Event.StartIsStarredUpdate(position, false))
-                }
-            }
-
-            _jobSparseArray[position].join()
-
-            _jobSparseArray[position] = null
-        }
-    }
-
     fun cancelJob(position: Int) {
         if (_jobSparseArray[position].isActive) _jobSparseArray[position].cancel()
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
 import androidx.paging.PagingData
+import androidx.paging.map
 import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.GitHubApiException
 import com.prac.data.repository.RepoRepository
@@ -47,6 +48,18 @@ class MainViewModel @Inject constructor(
             repoRepository.getRepositories().collect { pagingData ->
                 _uiState.update { UiState.ShowPagingData(pagingData) }
             }
+        }
+    }
+
+    fun transformPagingData(id: Int, isStarred: Boolean) {
+        _uiState.update {
+            UiState.ShowPagingData(
+                (it as UiState.ShowPagingData).repositories
+                    .map { repoEntity ->
+                        if (repoEntity.id == id) repoEntity.copy(isStarred = isStarred)
+                        else repoEntity
+                    }
+            )
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -49,7 +49,7 @@ class MainViewModel @Inject constructor(
 
     private val _jobSparseArray = SparseArray<Job>()
 
-    fun getRepositories() {
+    private fun getRepositories() {
         viewModelScope.launch {
             if (_uiState.value != UiState.Idle) return@launch
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -54,7 +54,7 @@ class MainViewModel @Inject constructor(
         }
     }
 
-    fun transformPagingData(id: Int, isStarred: Boolean) {
+    fun updateIsStarred(id: Int, isStarred: Boolean) {
         _uiState.update {
             UiState.ShowPagingData(
                 (it as UiState.ShowPagingData).repositories

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -33,19 +33,12 @@ class MainViewModel @Inject constructor(
         ) : UiState()
     }
 
-    sealed class Event {
-        data class StartIsStarredUpdate(val position: Int, val isStarred: Boolean) : Event()
-    }
-
     init {
         getRepositories()
     }
 
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
-
-    private val _event = MutableSharedFlow<Event>()
-    val event = _event.asSharedFlow()
 
     private fun getRepositories() {
         viewModelScope.launch {

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -44,7 +44,7 @@ class MainViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
 
-    private val _isStarredUpdate = MutableSharedFlow<Pair<Int, Boolean>>()
+    private val _isStarredUpdate = MutableStateFlow<List<Pair<Int, Boolean>>>(emptyList())
 
     private fun getRepositories() {
         viewModelScope.launch {
@@ -52,21 +52,16 @@ class MainViewModel @Inject constructor(
 
             combine(
                 repoRepository.getRepositories().cachedIn(viewModelScope),
-                _isStarredUpdate.scan(emptyMap<Int, Boolean>()) { acc, (id, isStarred) ->
-                    acc + (id to isStarred)
-                }) { pagingData, starredMap ->
-                pagingData.map { repoEntity ->
-                    repoEntity.copy(isStarred = starredMap[repoEntity.id] ?: repoEntity.isStarred)
-                }
-            }.collect { transformedPagingData ->
-                _uiState.update { UiState.ShowPagingData(transformedPagingData) }
+                _isStarredUpdate
+                ) { pagingData, starredMap ->
+
             }
         }
     }
 
     fun updateIsStarred(id: Int, isStarred: Boolean) {
         viewModelScope.launch {
-            _isStarredUpdate.emit(Pair(id, isStarred))
+
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -53,9 +53,17 @@ class MainViewModel @Inject constructor(
             combine(
                 repoRepository.getRepositories().cachedIn(viewModelScope),
                 _isStarredList
-                ) { pagingData, isStarredList ->
-
+            ) { pagingData, isStarredList ->
+                isStarredList.fold(pagingData) { acc, pair ->
+                    acc.map { repoEntity ->
+                        if (repoEntity.id == pair.first) repoEntity.copy(isStarred = pair.second)
+                        else repoEntity
+                    }
+                }
+            }.collect { transformedPagingData ->
+                _uiState.update { UiState.ShowPagingData(transformedPagingData) }
             }
+
         }
     }
 

--- a/data/src/main/java/com/prac/data/di/DataSourceModule.kt
+++ b/data/src/main/java/com/prac/data/di/DataSourceModule.kt
@@ -2,11 +2,13 @@ package com.prac.data.di
 
 import com.prac.data.di.datastore.TokenDataStoreManager
 import com.prac.data.source.RepoApiDataSource
+import com.prac.data.source.RepoStarApiDataSource
 import com.prac.data.source.TokenApiDataSource
 import com.prac.data.source.TokenLocalDataSource
 import com.prac.data.source.api.GitHubApi
 import com.prac.data.source.api.GitHubTokenApi
 import com.prac.data.source.impl.RepoApiDataSourceImpl
+import com.prac.data.source.impl.RepoStarApiDataSourceImpl
 import com.prac.data.source.impl.TokenApiDataSourceImpl
 import com.prac.data.source.impl.TokenLocalDataSourceImpl
 import dagger.Module
@@ -34,4 +36,10 @@ internal object DataSourceModule {
         gitHubApi: GitHubApi
     ): RepoApiDataSource =
         RepoApiDataSourceImpl(gitHubApi)
+
+    @Provides
+    fun provideRepoStarApiDataSource(
+        gitHubApi: GitHubApi
+    ): RepoStarApiDataSource =
+        RepoStarApiDataSourceImpl(gitHubApi)
 }

--- a/data/src/main/java/com/prac/data/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/di/RepositoryModule.kt
@@ -5,6 +5,7 @@ import com.prac.data.repository.TokenRepository
 import com.prac.data.repository.impl.RepoRepositoryImpl
 import com.prac.data.repository.impl.TokenRepositoryImpl
 import com.prac.data.source.RepoApiDataSource
+import com.prac.data.source.RepoStarApiDataSource
 import com.prac.data.source.TokenApiDataSource
 import com.prac.data.source.TokenLocalDataSource
 import dagger.Module
@@ -26,7 +27,8 @@ internal object RepositoryModule {
 
     @Provides
     fun provideRepoRepository(
-        repoApiDataSource: RepoApiDataSource
+        repoApiDataSource: RepoApiDataSource,
+        repoStarApiDataSource: RepoStarApiDataSource
     ): RepoRepository =
-        RepoRepositoryImpl(repoApiDataSource)
+        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource)
 }

--- a/data/src/main/java/com/prac/data/entity/RepoEntity.kt
+++ b/data/src/main/java/com/prac/data/entity/RepoEntity.kt
@@ -5,5 +5,6 @@ data class RepoEntity(
     val name: String,
     val owner: OwnerEntity,
     val stargazersCount: Int,
-    val updatedAt: String
+    val updatedAt: String,
+    var isStarred: Boolean?
 )

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -6,4 +6,6 @@ import kotlinx.coroutines.flow.Flow
 
 interface RepoRepository {
     suspend fun getRepositories() : Flow<PagingData<RepoEntity>>
+
+    suspend fun checkRepositoryIsStarred(repoName: String) : Result<Boolean>
 }

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -7,5 +7,5 @@ import kotlinx.coroutines.flow.Flow
 interface RepoRepository {
     suspend fun getRepositories() : Flow<PagingData<RepoEntity>>
 
-    suspend fun checkRepositoryIsStarred(repoName: String) : Result<Boolean>
+    suspend fun isStarred(repoName: String) : Result<Boolean>
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -4,6 +4,7 @@ import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
 import androidx.paging.map
+import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.RepoApiDataSource
@@ -25,7 +26,7 @@ internal class RepoRepositoryImpl @Inject constructor(
         ).flow
             .map { pagingData ->
                 pagingData.map { repoModel ->
-                    repoModel.toEntity()
+                    RepoEntity(repoModel.id, repoModel.name, OwnerEntity(repoModel.owner.login, repoModel.owner.avatarUrl), repoModel.stargazersCount, repoModel.updatedAt)
                 }
             }
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -33,8 +33,13 @@ internal class RepoRepositoryImpl @Inject constructor(
             }
 
     override suspend fun checkRepositoryIsStarred(repoName: String): Result<Boolean> {
-        // TODO call repoStarApiDataSource checkRepositoryIsStarred
-        return Result.success(false)
+        return try {
+            val result = repoStarApiDataSource.checkRepositoryIsStarred(repoName)
+
+            Result.success(result)
+        } catch (e: Exception) {
+            Result.success(false)
+        }
     }
 }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -32,7 +32,7 @@ internal class RepoRepositoryImpl @Inject constructor(
                 }
             }
 
-    override suspend fun checkRepositoryIsStarred(repoName: String): Result<Boolean> {
+    override suspend fun isStarred(repoName: String): Result<Boolean> {
         return try {
             val result = repoStarApiDataSource.checkRepositoryIsStarred(repoName)
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -10,7 +10,6 @@ import com.prac.data.repository.RepoRepository
 import com.prac.data.source.RepoApiDataSource
 import com.prac.data.source.RepoStarApiDataSource
 import com.prac.data.source.impl.RepoApiDataSourceImpl.Companion.PAGE_SIZE
-import com.prac.data.source.impl.RepoStarApiDataSourceImpl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -32,5 +31,10 @@ internal class RepoRepositoryImpl @Inject constructor(
                     RepoEntity(repoModel.id, repoModel.name, OwnerEntity(repoModel.owner.login, repoModel.owner.avatarUrl), repoModel.stargazersCount, repoModel.updatedAt, null)
                 }
             }
+
+    override suspend fun checkRepositoryIsStarred(repoName: String): Result<Boolean> {
+        // TODO call repoStarApiDataSource checkRepositoryIsStarred
+        return Result.success(false)
+    }
 }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -38,7 +38,7 @@ internal class RepoRepositoryImpl @Inject constructor(
 
             Result.success(result)
         } catch (e: Exception) {
-            Result.success(false)
+            Result.failure(e)
         }
     }
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -26,7 +26,7 @@ internal class RepoRepositoryImpl @Inject constructor(
         ).flow
             .map { pagingData ->
                 pagingData.map { repoModel ->
-                    RepoEntity(repoModel.id, repoModel.name, OwnerEntity(repoModel.owner.login, repoModel.owner.avatarUrl), repoModel.stargazersCount, repoModel.updatedAt)
+                    RepoEntity(repoModel.id, repoModel.name, OwnerEntity(repoModel.owner.login, repoModel.owner.avatarUrl), repoModel.stargazersCount, repoModel.updatedAt, null)
                 }
             }
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -8,13 +8,16 @@ import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.RepoApiDataSource
+import com.prac.data.source.RepoStarApiDataSource
 import com.prac.data.source.impl.RepoApiDataSourceImpl.Companion.PAGE_SIZE
+import com.prac.data.source.impl.RepoStarApiDataSourceImpl
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
 
 internal class RepoRepositoryImpl @Inject constructor(
-    private val repoApiDataSource: RepoApiDataSource
+    private val repoApiDataSource: RepoApiDataSource,
+    private val repoStarApiDataSource: RepoStarApiDataSource
 ) : RepoRepository {
     override suspend fun getRepositories(): Flow<PagingData<RepoEntity>> =
         Pager(

--- a/data/src/main/java/com/prac/data/repository/model/OwnerModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/OwnerModel.kt
@@ -1,11 +1,6 @@
 package com.prac.data.repository.model
 
-import com.prac.data.entity.OwnerEntity
-
 internal data class OwnerModel(
     val login: String,
     val avatarUrl: String
-) {
-    fun toEntity() =
-        OwnerEntity(login, avatarUrl)
-}
+)

--- a/data/src/main/java/com/prac/data/repository/model/RepoModel.kt
+++ b/data/src/main/java/com/prac/data/repository/model/RepoModel.kt
@@ -1,14 +1,9 @@
 package com.prac.data.repository.model
 
-import com.prac.data.entity.RepoEntity
-
 internal data class RepoModel(
     val id: Int,
     val name: String,
     val owner: OwnerModel,
     val stargazersCount: Int,
     val updatedAt: String
-) {
-    fun toEntity() =
-        RepoEntity(id, name, owner.toEntity(), stargazersCount, updatedAt)
-}
+)

--- a/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
@@ -1,0 +1,5 @@
+package com.prac.data.source
+
+internal interface RepoStarApiDataSource {
+    suspend fun checkRepositoryIsStarred(repoName: String) : Boolean
+}

--- a/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
+++ b/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
@@ -19,5 +19,5 @@ internal interface GitHubApi {
     suspend fun checkRepositoryIsStarred(
         @Path("userName") userName: String,
         @Path("repoName") repoName: String
-    ): Response<Unit>
+    )
 }

--- a/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
+++ b/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
@@ -1,6 +1,7 @@
 package com.prac.data.source.api
 
 import com.prac.data.source.dto.RepoDto
+import retrofit2.Response
 import retrofit2.http.GET
 import retrofit2.http.Path
 import retrofit2.http.Query
@@ -12,4 +13,11 @@ internal interface GitHubApi {
         @Query("per_page") perPage: Int,
         @Query("page") page: Int
     ): List<RepoDto>
+
+
+    @GET("user/starred/{userName}/{repoName}")
+    suspend fun checkRepositoryIsStarred(
+        @Path("userName") userName: String,
+        @Path("repoName") repoName: String
+    ): Response<Unit>
 }

--- a/data/src/main/java/com/prac/data/source/dto/OwnerDto.kt
+++ b/data/src/main/java/com/prac/data/source/dto/OwnerDto.kt
@@ -1,6 +1,5 @@
 package com.prac.data.source.dto
 
-import com.prac.data.repository.model.OwnerModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -8,7 +7,4 @@ import kotlinx.serialization.Serializable
 internal data class OwnerDto(
     @SerialName("login") val login: String = "",
     @SerialName("avatar_url") val avatarUrl: String = ""
-) {
-    fun toModel() =
-        OwnerModel(login, avatarUrl)
-}
+)

--- a/data/src/main/java/com/prac/data/source/dto/RepoDto.kt
+++ b/data/src/main/java/com/prac/data/source/dto/RepoDto.kt
@@ -1,6 +1,5 @@
 package com.prac.data.source.dto
 
-import com.prac.data.repository.model.RepoModel
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,7 +10,4 @@ internal data class RepoDto(
     @SerialName("owner") val owner: OwnerDto = OwnerDto(),
     @SerialName("stargazers_count") val stargazersCount: Int = 0,
     @SerialName("updated_at") val updatedAt: String = ""
-) {
-    fun toModel() =
-        RepoModel(id, name, owner.toModel(), stargazersCount, updatedAt)
-}
+)

--- a/data/src/main/java/com/prac/data/source/impl/RepoApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoApiDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.prac.data.source.impl
 
 import androidx.paging.PagingState
+import com.prac.data.repository.model.OwnerModel
 import com.prac.data.repository.model.RepoModel
 import com.prac.data.source.RepoApiDataSource
 import com.prac.data.source.api.GitHubApi
@@ -27,7 +28,9 @@ internal class RepoApiDataSourceImpl @Inject constructor(
             }
 
             return LoadResult.Page(
-                data = response.map { it.toModel() },
+                data = response.map {
+                    RepoModel(it.id, it.name, OwnerModel(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt)
+                },
                 prevKey = if (position == STARTING_PAGE_INDEX) null else position - 1,
                 nextKey = nextKey
             )

--- a/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
@@ -8,8 +8,11 @@ internal class RepoStarApiDataSourceImpl @Inject constructor(
     private val gitHubApi: GitHubApi
 ): RepoStarApiDataSource {
     override suspend fun checkRepositoryIsStarred(repoName: String) : Boolean {
-        val response = gitHubApi.checkRepositoryIsStarred("GongDoMin", repoName)
-
-        return response.code() == 204
+        return try {
+            gitHubApi.checkRepositoryIsStarred("GongDoMin", repoName)
+            true
+        } catch (e: Exception) {
+            false
+        }
     }
 }

--- a/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
@@ -1,0 +1,15 @@
+package com.prac.data.source.impl
+
+import com.prac.data.source.RepoStarApiDataSource
+import com.prac.data.source.api.GitHubApi
+import javax.inject.Inject
+
+internal class RepoStarApiDataSourceImpl @Inject constructor(
+    private val gitHubApi: GitHubApi
+): RepoStarApiDataSource {
+    override suspend fun checkRepositoryIsStarred(repoName: String) : Boolean {
+        val response = gitHubApi.checkRepositoryIsStarred("GongDoMin", repoName)
+
+        return response.code() == 204
+    }
+}


### PR DESCRIPTION
notion - https://www.notion.so/feat-refact-repo-data-class-d78e606918fc4ef29803f579c84488ef?pvs=4

## AS-IS
- 기존에 존재하는 toModel, toEntity 메서드는 클린 아키텍쳐 관점에서 잘못된 메서드이다.

## 작업 사항
- toModel, toEntity 메서드를 제거하고 데이터를 변환할 때 data class 생성자를 통해서 변환한다.

## TO-BE
- #46 