### PR TITLE
feat: 레포지토리 star를 확인하고 UI 업데이트를 수행하는 RepoStarUpdater 클래스 추가

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -24,5 +24,14 @@ class RepoStarUpdater(
 
     private fun cancelUpdatingStarState() {
         request.cancel()
+
+        maybeRemoveListener()
+    }
+
+    fun maybeRemoveListener() {
+        if (!isAttachedStateListenerAdded) return
+
+        isAttachedStateListenerAdded = false
+        view.removeOnAttachStateChangeListener(attachedStateListener)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -28,7 +28,7 @@ class RepoStarUpdater(
         maybeRemoveListener()
     }
 
-    fun maybeAddListener() {
+    fun addListener() {
         view.removeOnAttachStateChangeListener(attachedStateListener)
         view.addOnAttachStateChangeListener(attachedStateListener)
     }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -1,0 +1,20 @@
+package com.prac.githubrepo.main
+
+import android.view.View
+import com.prac.githubrepo.main.request.Request
+
+class RepoStarUpdater(
+    private val request: Request,
+    private val view: View
+) {
+    private var isAttachedStateListenerAdded = false
+    private val attachedStateListener = object : View.OnAttachStateChangeListener {
+        override fun onViewAttachedToWindow(view: View) {
+
+        }
+
+        override fun onViewDetachedFromWindow(view: View) {
+
+        }
+    }
+}

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -28,6 +28,13 @@ class RepoStarUpdater(
         maybeRemoveListener()
     }
 
+    fun maybeAddListener() {
+        if (isAttachedStateListenerAdded) return
+
+        isAttachedStateListenerAdded = true
+        view.addOnAttachStateChangeListener(attachedStateListener)
+    }
+
     fun maybeRemoveListener() {
         if (!isAttachedStateListenerAdded) return
 

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -14,11 +14,15 @@ class RepoStarUpdater(
         }
 
         override fun onViewDetachedFromWindow(view: View) {
-
+            cancelUpdatingStarState()
         }
     }
 
     private fun startUpdatingStarState() {
         request.checkStarredState()
+    }
+
+    private fun cancelUpdatingStarState() {
+        request.cancel()
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -29,9 +29,7 @@ class RepoStarUpdater(
     }
 
     fun maybeAddListener() {
-        if (isAttachedStateListenerAdded) return
-
-        isAttachedStateListenerAdded = true
+        view.removeOnAttachStateChangeListener(attachedStateListener)
         view.addOnAttachStateChangeListener(attachedStateListener)
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -24,7 +24,7 @@ class RepoStarUpdater(
     private fun cancelUpdatingStarState() {
         request.cancel()
 
-        maybeRemoveListener()
+        removeListener()
     }
 
     fun addListener() {
@@ -32,7 +32,7 @@ class RepoStarUpdater(
         view.addOnAttachStateChangeListener(attachedStateListener)
     }
 
-    fun maybeRemoveListener() {
+    fun removeListener() {
         view.removeOnAttachStateChangeListener(attachedStateListener)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -10,11 +10,15 @@ class RepoStarUpdater(
     private var isAttachedStateListenerAdded = false
     private val attachedStateListener = object : View.OnAttachStateChangeListener {
         override fun onViewAttachedToWindow(view: View) {
-
+            startUpdatingStarState()
         }
 
         override fun onViewDetachedFromWindow(view: View) {
 
         }
+    }
+
+    private fun startUpdatingStarState() {
+        request.checkStarredState()
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -7,7 +7,6 @@ class RepoStarUpdater(
     private val request: Request,
     private val view: View
 ) {
-    private var isAttachedStateListenerAdded = false
     private val attachedStateListener = object : View.OnAttachStateChangeListener {
         override fun onViewAttachedToWindow(view: View) {
             startUpdatingStarState()
@@ -34,9 +33,6 @@ class RepoStarUpdater(
     }
 
     fun maybeRemoveListener() {
-        if (!isAttachedStateListenerAdded) return
-
-        isAttachedStateListenerAdded = false
         view.removeOnAttachStateChangeListener(attachedStateListener)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -1,5 +1,6 @@
 package com.prac.githubrepo.main.request
 
+import android.view.View
 import com.prac.data.repository.RepoRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -13,5 +14,11 @@ class RequestBuilder @AssistedInject constructor(
     @AssistedFactory
     interface Factory {
         fun create(scope: CoroutineScope): RequestBuilder
+    }
+
+    private var view: View? = null
+
+    fun setView(view: View) : RequestBuilder = apply {
+        this.view = view
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -47,7 +47,7 @@ class RequestBuilder @AssistedInject constructor(
             view = view
         )
 
-        if (view.hasUpdaterTag()) (view.getTag(tagID) as RepoStarUpdater).maybeRemoveListener()
+        if (view.hasUpdaterTag()) (view.getTag(tagID) as RepoStarUpdater).removeListener()
 
         view.setTag(tagID, updater)
 

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -1,0 +1,17 @@
+package com.prac.githubrepo.main.request
+
+import com.prac.data.repository.RepoRepository
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
+import kotlinx.coroutines.CoroutineScope
+
+class RequestBuilder @AssistedInject constructor(
+    private val repoRepository: RepoRepository,
+    @Assisted private val scope: CoroutineScope
+) {
+    @AssistedFactory
+    interface Factory {
+        fun create(scope: CoroutineScope): RequestBuilder
+    }
+}

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -51,7 +51,7 @@ class RequestBuilder @AssistedInject constructor(
 
         view.setTag(tagID, updater)
 
-        if (repoEntity.isStarred == null) updater.maybeAddListener()
+        if (repoEntity.isStarred == null) updater.addListener()
 
         clear()
     }

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -1,6 +1,7 @@
 package com.prac.githubrepo.main.request
 
 import android.view.View
+import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
@@ -17,8 +18,13 @@ class RequestBuilder @AssistedInject constructor(
     }
 
     private var view: View? = null
+    private var repoEntity: RepoEntity? = null
 
     fun setView(view: View) : RequestBuilder = apply {
         this.view = view
+    }
+
+    fun setRepoEntity(repoEntity: RepoEntity) = apply {
+        this.repoEntity = repoEntity
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -4,6 +4,7 @@ import android.view.View
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.githubrepo.R
+import com.prac.githubrepo.main.RepoStarUpdater
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -31,6 +32,28 @@ class RequestBuilder @AssistedInject constructor(
 
     fun setRepoEntity(repoEntity: RepoEntity) = apply {
         this.repoEntity = repoEntity
+    }
+
+    fun build() {
+        val view = checkNotNull(view)
+        val repoEntity = checkNotNull(repoEntity)
+
+        val updater = RepoStarUpdater(
+            request = StarRequest(
+                repoRepository = repoRepository,
+                repoEntity = repoEntity,
+                scope = scope
+            ),
+            view = view
+        )
+
+        if (view.hasUpdaterTag()) (view.getTag(tagID) as RepoStarUpdater).maybeRemoveListener()
+
+        view.setTag(tagID, updater)
+
+        if (repoEntity.isStarred == null) updater.maybeAddListener()
+
+        clear()
     }
 
     private fun View.hasUpdaterTag() : Boolean {

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -27,4 +27,9 @@ class RequestBuilder @AssistedInject constructor(
     fun setRepoEntity(repoEntity: RepoEntity) = apply {
         this.repoEntity = repoEntity
     }
+
+    private fun clear() = apply {
+        this.view = null
+        this.repoEntity = null
+    }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -33,6 +33,14 @@ class RequestBuilder @AssistedInject constructor(
         this.repoEntity = repoEntity
     }
 
+    private fun View.hasUpdaterTag() : Boolean {
+        val tag = getTag(tagID) ?: return false
+
+        if (tag !is Request) throw IllegalStateException("Tag is not of type Request")
+
+        return true
+    }
+
     private fun clear() = apply {
         this.view = null
         this.repoEntity = null

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -3,6 +3,7 @@ package com.prac.githubrepo.main.request
 import android.view.View
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.R
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
@@ -12,6 +13,10 @@ class RequestBuilder @AssistedInject constructor(
     private val repoRepository: RepoRepository,
     @Assisted private val scope: CoroutineScope
 ) {
+    companion object {
+        private val tagID = R.string.requestID
+    }
+
     @AssistedFactory
     interface Factory {
         fun create(scope: CoroutineScope): RequestBuilder

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,4 +8,6 @@
     <string name="login_github_login">GitHub Login</string>
 
     <string name="main_title">Repository</string>
+
+    <string name="requestID">requestID</string>
 </resources>


### PR DESCRIPTION
notion - https://www.notion.so/feat-star-UI-StarRequest-9dd93ef5e2a749b28d3f1679d95b1850?pvs=4

## AS-IS
- view의 onAttachStateChangedListener 를 관리하고 있지 않다.
- view가 attach 될 때 Request를 요청하여 star 상태를 확인하고 있지 않다.
- view가 detach 될 때 Request를 작업을 취소하고 있지 않다.

## 작업 사항
- RepoStarUpdater 클래스 생성

## TO-BE
- #56 