### PR TITLE
refactor: View 의 Tag 타입을 판단하는 로직 변경

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -59,7 +59,7 @@ class RequestBuilder @AssistedInject constructor(
     private fun View.hasUpdaterTag() : Boolean {
         val tag = getTag(tagID) ?: return false
 
-        if (tag !is Request) throw IllegalStateException("Tag is not of type Request")
+        if (tag !is RepoStarUpdater) throw IllegalStateException("Tag is not of type RepoStarUpdater")
 
         return true
     }


### PR DESCRIPTION
notion - https://www.notion.so/refactor-View-Tag-20f10b855fa34ae184a731ff6583187d?pvs=4

## AS-IS
```kotlin
val updater = RepoStarUpdater(
	....
)

view.setTag(tagID, updater)
``` 
```kotlin
val tag = getTag(tagID) ?: return false

if (tag !is Request) throw IllegalStateException("Tag is not of type Request")
``` 
- RequestBuilder 를 통해서 View 의 Tag 에 RepoStarUpdater 를 넣었지만 View의 Tag 가 Request 인지 판단하고 있다.

## 작업 사항
- Request 인지 판단하는 대신 RepoStarUpdater 으로 변경
