### PR TITLE
refact: Request 네이밍 변경

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun unStar(repoEntity: RepoEntity) {
-            TODO("Not yet implemented")
+            mainViewModel.unStarRepository(repoEntity)
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -25,7 +25,12 @@ class MainActivity : AppCompatActivity() {
     private lateinit var binding: ActivityMainBinding
     private val viewModel: MainViewModel by viewModels()
     @Inject lateinit var starStateRequestBuilderFactory: StarStateRequestBuilder.Factory
-    private val mainAdapter: MainAdapter by lazy { MainAdapter(starStateRequestBuilderFactory.create(this.lifecycleScope)) }
+    private val mainAdapter: MainAdapter by lazy {
+        MainAdapter(
+            starStateRequestBuilderFactory.create(this.lifecycleScope),
+            StarClickListenerImpl(viewModel)
+        )
+    }
     private val retryFooterAdapter: RetryFooterAdapter by lazy { RetryFooterAdapter { mainAdapter.retry() } }
     private val conCatAdapter: ConcatAdapter by lazy { ConcatAdapter(mainAdapter, retryFooterAdapter) }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -93,5 +93,9 @@ class MainActivity : AppCompatActivity() {
         override fun star(repoEntity: RepoEntity) {
             mainViewModel.starRepository(repoEntity)
         }
+
+        override fun unStar(repoEntity: RepoEntity) {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -10,6 +10,7 @@ import androidx.paging.CombinedLoadStates
 import androidx.paging.LoadState
 import androidx.recyclerview.widget.ConcatAdapter
 import androidx.recyclerview.widget.LinearLayoutManager
+import com.prac.data.entity.RepoEntity
 import com.prac.githubrepo.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
@@ -78,6 +79,14 @@ class MainActivity : AppCompatActivity() {
 
                 mainAdapter.submitData(this.repositories)
             }
+        }
+    }
+
+    private class StarClickListenerImpl(
+         private val mainViewModel: MainViewModel
+    ) : MainAdapter.StarClickListener {
+        override fun star(repoEntity: RepoEntity) {
+            TODO("Not yet implemented")
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -91,7 +91,7 @@ class MainActivity : AppCompatActivity() {
          private val mainViewModel: MainViewModel
     ) : MainAdapter.StarClickListener {
         override fun star(repoEntity: RepoEntity) {
-            TODO("Not yet implemented")
+            mainViewModel.starRepository(repoEntity)
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -28,7 +28,7 @@ class MainActivity : AppCompatActivity() {
     private val mainAdapter: MainAdapter by lazy {
         MainAdapter(
             starStateRequestBuilderFactory.create(this.lifecycleScope),
-            StarClickListenerImpl(viewModel)
+            OnStarClickListenerImpl(viewModel)
         )
     }
     private val retryFooterAdapter: RetryFooterAdapter by lazy { RetryFooterAdapter { mainAdapter.retry() } }
@@ -87,9 +87,9 @@ class MainActivity : AppCompatActivity() {
         }
     }
 
-    private class StarClickListenerImpl(
+    private class OnStarClickListenerImpl(
          private val mainViewModel: MainViewModel
-    ) : MainAdapter.StarClickListener {
+    ) : MainAdapter.OnStarClickListener {
         override fun star(repoEntity: RepoEntity) {
             mainViewModel.starRepository(repoEntity)
         }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -14,7 +14,7 @@ import com.prac.githubrepo.databinding.ActivityMainBinding
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import com.prac.githubrepo.main.MainViewModel.UiState
-import com.prac.githubrepo.main.request.RequestBuilder
+import com.prac.githubrepo.main.request.StarStateRequestBuilder
 import kotlinx.coroutines.flow.collectLatest
 import javax.inject.Inject
 
@@ -23,8 +23,8 @@ class MainActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityMainBinding
     private val viewModel: MainViewModel by viewModels()
-    @Inject lateinit var requestBuilderFactory: RequestBuilder.Factory
-    private val mainAdapter: MainAdapter by lazy { MainAdapter(requestBuilderFactory.create(this.lifecycleScope)) }
+    @Inject lateinit var starStateRequestBuilderFactory: StarStateRequestBuilder.Factory
+    private val mainAdapter: MainAdapter by lazy { MainAdapter(starStateRequestBuilderFactory.create(this.lifecycleScope)) }
     private val retryFooterAdapter: RetryFooterAdapter by lazy { RetryFooterAdapter { mainAdapter.retry() } }
     private val conCatAdapter: ConcatAdapter by lazy { ConcatAdapter(mainAdapter, retryFooterAdapter) }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -14,12 +14,12 @@ import com.prac.githubrepo.main.request.StarStateRequestBuilder
 
 class MainAdapter(
     private val starStateRequestBuilder: StarStateRequestBuilder,
-    private val starClickListener: StarClickListener
+    private val onStarClickListener: OnStarClickListener
 ) : PagingDataAdapter<RepoEntity, MainAdapter.ViewHolder>(diffUtil) {
     class ViewHolder(
         private val binding: ItemMainBinding,
         private val starStateRequestBuilder: StarStateRequestBuilder,
-        private val starClickListener: StarClickListener
+        private val onStarClickListener: OnStarClickListener
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(repoEntity: RepoEntity) {
             with(repoEntity) {
@@ -32,7 +32,7 @@ class MainAdapter(
                 setUpdatedDate()
             }
 
-            binding.ivStar.setStarClickListener(repoEntity, starClickListener)
+            binding.ivStar.setStarClickListener(repoEntity, onStarClickListener)
         }
 
         private fun setRequestBuilder(view: View, repoEntity: RepoEntity) {
@@ -74,15 +74,15 @@ class MainAdapter(
 
         private fun View.setStarClickListener(
             repoEntity: RepoEntity,
-            starClickListener: StarClickListener
+            onStarClickListener: OnStarClickListener
         ) {
             setOnClickListener {
                 if (repoEntity.isStarred == true) {
-                    starClickListener.unStar(repoEntity)
+                    onStarClickListener.unStar(repoEntity)
                     return@setOnClickListener
                 }
 
-                starClickListener.star(repoEntity)
+                onStarClickListener.star(repoEntity)
             }
         }
     }
@@ -91,7 +91,7 @@ class MainAdapter(
         return ViewHolder(
             ItemMainBinding.inflate(LayoutInflater.from(parent.context), parent, false),
             starStateRequestBuilder,
-            starClickListener
+            onStarClickListener
         )
     }
 
@@ -109,7 +109,7 @@ class MainAdapter(
         }
     }
 
-    interface StarClickListener {
+    interface OnStarClickListener {
         fun star(repoEntity: RepoEntity)
         fun unStar(repoEntity: RepoEntity)
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -31,6 +31,8 @@ class MainAdapter(
                 setStarCount()
                 setUpdatedDate()
             }
+
+            binding.ivStar.setStarClickListener(repoEntity, starClickListener)
         }
 
         private fun setRequestBuilder(view: View, repoEntity: RepoEntity) {
@@ -68,6 +70,15 @@ class MainAdapter(
 
         private fun RepoEntity.setUpdatedDate() {
             binding.tvLastUpdatedDate.text = this.updatedAt
+        }
+
+        private fun View.setStarClickListener(
+            repoEntity: RepoEntity,
+            starClickListener: StarClickListener
+        ) {
+            setOnClickListener {
+                if (repoEntity.isStarred == false) starClickListener.star(repoEntity)
+            }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -13,7 +13,8 @@ import com.prac.githubrepo.databinding.ItemMainBinding
 import com.prac.githubrepo.main.request.StarStateRequestBuilder
 
 class MainAdapter(
-    private val starStateRequestBuilder: StarStateRequestBuilder
+    private val starStateRequestBuilder: StarStateRequestBuilder,
+    private val starClickListener: StarClickListener
 ) : PagingDataAdapter<RepoEntity, MainAdapter.ViewHolder>(diffUtil) {
     class ViewHolder(
         private val binding: ItemMainBinding,

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -10,14 +10,14 @@ import com.bumptech.glide.Glide
 import com.prac.data.entity.RepoEntity
 import com.prac.githubrepo.R
 import com.prac.githubrepo.databinding.ItemMainBinding
-import com.prac.githubrepo.main.request.RequestBuilder
+import com.prac.githubrepo.main.request.StarStateRequestBuilder
 
 class MainAdapter(
-    private val requestBuilder: RequestBuilder
+    private val starStateRequestBuilder: StarStateRequestBuilder
 ) : PagingDataAdapter<RepoEntity, MainAdapter.ViewHolder>(diffUtil) {
     class ViewHolder(
         private val binding: ItemMainBinding,
-        private val requestBuilder: RequestBuilder
+        private val starStateRequestBuilder: StarStateRequestBuilder
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(repoEntity: RepoEntity) {
             with(repoEntity) {
@@ -32,7 +32,7 @@ class MainAdapter(
         }
 
         private fun setRequestBuilder(view: View, repoEntity: RepoEntity) {
-            requestBuilder.setView(view)
+            starStateRequestBuilder.setView(view)
                 .setRepoEntity(repoEntity)
                 .build()
         }
@@ -72,7 +72,7 @@ class MainAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(
             ItemMainBinding.inflate(LayoutInflater.from(parent.context), parent, false),
-            requestBuilder
+            starStateRequestBuilder
         )
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -89,4 +89,8 @@ class MainAdapter(
                 oldItem == newItem
         }
     }
+
+    interface StarClickListener {
+        fun star(repoEntity: RepoEntity)
+    }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -106,5 +106,6 @@ class MainAdapter(
 
     interface StarClickListener {
         fun star(repoEntity: RepoEntity)
+        fun unStar(repoEntity: RepoEntity)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -18,7 +18,8 @@ class MainAdapter(
 ) : PagingDataAdapter<RepoEntity, MainAdapter.ViewHolder>(diffUtil) {
     class ViewHolder(
         private val binding: ItemMainBinding,
-        private val starStateRequestBuilder: StarStateRequestBuilder
+        private val starStateRequestBuilder: StarStateRequestBuilder,
+        private val starClickListener: StarClickListener
     ) : RecyclerView.ViewHolder(binding.root) {
         fun bind(repoEntity: RepoEntity) {
             with(repoEntity) {
@@ -73,7 +74,8 @@ class MainAdapter(
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
         return ViewHolder(
             ItemMainBinding.inflate(LayoutInflater.from(parent.context), parent, false),
-            starStateRequestBuilder
+            starStateRequestBuilder,
+            starClickListener
         )
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -77,7 +77,12 @@ class MainAdapter(
             starClickListener: StarClickListener
         ) {
             setOnClickListener {
-                if (repoEntity.isStarred == false) starClickListener.star(repoEntity)
+                if (repoEntity.isStarred == true) {
+                    starClickListener.unStar(repoEntity)
+                    return@setOnClickListener
+                }
+
+                starClickListener.star(repoEntity)
             }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -62,6 +62,27 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun starRepository(repoEntity: RepoEntity) {
+        starStateMediator.updateStarState(
+            id = repoEntity.id,
+            isStarred = true,
+            stargazersCount = repoEntity.stargazersCount + 1
+        )
+
+        viewModelScope.launch(Dispatchers.IO) {
+            repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    starStateMediator.updateStarState(
+                        id = repoEntity.id,
+                        isStarred = false,
+                        stargazersCount = repoEntity.stargazersCount
+                    )
+
+                    //TODO show alert dialog
+                }
+        }
+    }
+
     init {
         getRepositories()
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -38,10 +38,6 @@ class MainViewModel @Inject constructor(
         ) : UiState()
     }
 
-    init {
-        getRepositories()
-    }
-
     private val _uiState = MutableStateFlow<UiState>(UiState.Idle)
     val uiState = _uiState.asStateFlow()
 
@@ -64,5 +60,9 @@ class MainViewModel @Inject constructor(
             }
 
         }
+    }
+
+    init {
+        getRepositories()
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -83,6 +83,27 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun unStarRepository(repoEntity: RepoEntity) {
+        starStateMediator.updateStarState(
+            id = repoEntity.id,
+            isStarred = false,
+            stargazersCount = repoEntity.stargazersCount - 1
+        )
+
+        viewModelScope.launch(Dispatchers.IO) {
+            repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    starStateMediator.updateStarState(
+                        id = repoEntity.id,
+                        isStarred = true,
+                        stargazersCount = repoEntity.stargazersCount
+                    )
+
+                    //TODO show alert dialog
+                }
+        }
+    }
+
     init {
         getRepositories()
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -52,10 +52,10 @@ class MainViewModel @Inject constructor(
             combine(
                 repoRepository.getRepositories().cachedIn(viewModelScope),
                 starStateMediator.starStates
-            ) { pagingData, isStarredList ->
-                isStarredList.fold(pagingData) { acc, pair ->
+            ) { pagingData, starStates ->
+                starStates.fold(pagingData) { acc, item ->
                     acc.map { repoEntity ->
-                        if (repoEntity.id == pair.first) repoEntity.copy(isStarred = pair.second)
+                        if (repoEntity.id == item.id) repoEntity.copy(isStarred = item.isStarred, stargazersCount = item.stargazersCount)
                         else repoEntity
                     }
                 }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -1,10 +1,10 @@
 package com.prac.githubrepo.main
 
 import android.view.View
-import com.prac.githubrepo.main.request.Request
+import com.prac.githubrepo.main.request.StarStateRequest
 
 class RepoStarUpdater(
-    private val request: Request,
+    private val starStateRequest: StarStateRequest,
     private val view: View
 ) {
     private val attachedStateListener = object : View.OnAttachStateChangeListener {
@@ -18,11 +18,11 @@ class RepoStarUpdater(
     }
 
     private fun startUpdatingStarState() {
-        request.checkStarredState()
+        starStateRequest.checkStarredState()
     }
 
     private fun cancelUpdatingStarState() {
-        request.cancel()
+        starStateRequest.cancel()
 
         removeListener()
     }

--- a/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/RepoStarUpdater.kt
@@ -18,7 +18,7 @@ class RepoStarUpdater(
     }
 
     private fun startUpdatingStarState() {
-        starStateRequest.checkStarredState()
+        starStateRequest.fetchStarState()
     }
 
     private fun cancelUpdatingStarState() {

--- a/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
@@ -3,7 +3,7 @@ package com.prac.githubrepo.main
 import kotlinx.coroutines.flow.StateFlow
 
 interface StarStateMediator {
-    val starStates: StateFlow<List<Pair<Int, Boolean>>>
+    val starStates: StateFlow<List<StarState>>
 
     fun addStarState(id: Int, isStarred: Boolean)
 

--- a/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
@@ -7,6 +7,8 @@ interface StarStateMediator {
 
     fun addStarState(id: Int, isStarred: Boolean, stargazersCount: Int)
 
+    fun updateStarState(id: Int, isStarred: Boolean, stargazersCount: Int)
+
     data class StarState(
         val id: Int,
         val isStarred: Boolean,

--- a/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
@@ -6,4 +6,10 @@ interface StarStateMediator {
     val starStates: StateFlow<List<Pair<Int, Boolean>>>
 
     fun addStarState(id: Int, isStarred: Boolean)
+
+    data class StarState(
+        val id: Int,
+        val isStarred: Boolean,
+        val stargazersCount: Int
+    )
 }

--- a/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/StarStateMediator.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.StateFlow
 interface StarStateMediator {
     val starStates: StateFlow<List<StarState>>
 
-    fun addStarState(id: Int, isStarred: Boolean)
+    fun addStarState(id: Int, isStarred: Boolean, stargazersCount: Int)
 
     data class StarState(
         val id: Int,

--- a/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
@@ -24,7 +24,7 @@ class MediatorModule {
             override val starStates: StateFlow<List<StarState>>
                 get() = _starStates.asStateFlow()
 
-            override fun addStarState(id: Int, isStarred: Boolean) {
+            override fun addStarState(id: Int, isStarred: Boolean, stargazersCount: Int) {
                 _starStates.update {
                     // TODO("Not yet implemented")
                     it

--- a/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
@@ -29,6 +29,15 @@ class MediatorModule {
                     it + StarState(id, isStarred, stargazersCount)
                 }
             }
+
+            override fun updateStarState(id: Int, isStarred: Boolean, stargazersCount: Int) {
+                _starStates.update {
+                    it.map { starState ->
+                        if (starState.id == id) starState.copy(isStarred = isStarred, stargazersCount = stargazersCount)
+                        else starState
+                    }
+                }
+            }
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
@@ -1,6 +1,7 @@
 package com.prac.githubrepo.main.di
 
 import com.prac.githubrepo.main.StarStateMediator
+import com.prac.githubrepo.main.StarStateMediator.StarState
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -18,14 +19,15 @@ class MediatorModule {
     @ActivityRetainedScoped
     fun provideStarStateMediator() : StarStateMediator {
         return object : StarStateMediator {
-            private val _starStates = MutableStateFlow<List<Pair<Int, Boolean>>>(emptyList())
+            private val _starStates = MutableStateFlow<List<StarState>>(emptyList())
 
-            override val starStates: StateFlow<List<Pair<Int, Boolean>>>
+            override val starStates: StateFlow<List<StarState>>
                 get() = _starStates.asStateFlow()
 
             override fun addStarState(id: Int, isStarred: Boolean) {
                 _starStates.update {
-                    it + Pair(id, isStarred)
+                    // TODO("Not yet implemented")
+                    it
                 }
             }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/MediatorModule.kt
@@ -26,8 +26,7 @@ class MediatorModule {
 
             override fun addStarState(id: Int, isStarred: Boolean, stargazersCount: Int) {
                 _starStates.update {
-                    // TODO("Not yet implemented")
-                    it
+                    it + StarState(id, isStarred, stargazersCount)
                 }
             }
         }

--- a/app/src/main/java/com/prac/githubrepo/main/di/StarModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/StarModule.kt
@@ -21,9 +21,9 @@ class StarModule {
             override suspend fun fetchStarState(repoEntity: RepoEntity) {
                 repoRepository.isStarred(repoEntity.name)
                     .onSuccess {
-                        starStateMediator.addStarState(repoEntity.id, it)
+                        starStateMediator.addStarState(repoEntity.id, it, repoEntity.stargazersCount)
                     }.onFailure {
-                        starStateMediator.addStarState(repoEntity.id, false)
+                        starStateMediator.addStarState(repoEntity.id, false, repoEntity.stargazersCount)
                     }
             }
 

--- a/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/RequestBuilder.kt
@@ -39,7 +39,7 @@ class RequestBuilder @AssistedInject constructor(
         val repoEntity = checkNotNull(repoEntity)
 
         val updater = RepoStarUpdater(
-            request = StarRequest(
+            starStateRequest = StarStateRequestImpl(
                 starStateFetcher = starStateFetcher,
                 repoEntity = repoEntity,
                 scope = scope

--- a/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequest.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequest.kt
@@ -1,6 +1,6 @@
 package com.prac.githubrepo.main.request
 
-interface Request {
+interface StarStateRequest {
     fun checkStarredState()
     fun cancel()
     fun isCompleted() : Boolean

--- a/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequest.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequest.kt
@@ -1,7 +1,7 @@
 package com.prac.githubrepo.main.request
 
 interface StarStateRequest {
-    fun checkStarredState()
+    fun fetchStarState()
     fun cancel()
     fun isCompleted() : Boolean
 }

--- a/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestBuilder.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestBuilder.kt
@@ -10,7 +10,7 @@ import dagger.assisted.AssistedFactory
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.CoroutineScope
 
-class RequestBuilder @AssistedInject constructor(
+class StarStateRequestBuilder @AssistedInject constructor(
     private val starStateFetcher: StarStateFetcher,
     @Assisted private val scope: CoroutineScope,
 ) {
@@ -20,13 +20,13 @@ class RequestBuilder @AssistedInject constructor(
 
     @AssistedFactory
     interface Factory {
-        fun create(scope: CoroutineScope): RequestBuilder
+        fun create(scope: CoroutineScope): StarStateRequestBuilder
     }
 
     private var view: View? = null
     private var repoEntity: RepoEntity? = null
 
-    fun setView(view: View) : RequestBuilder = apply {
+    fun setView(view: View) : StarStateRequestBuilder = apply {
         this.view = view
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestImpl.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestImpl.kt
@@ -14,7 +14,7 @@ class StarStateRequestImpl internal constructor(
 ) : StarStateRequest {
     private var job: Job? = null
 
-    override fun checkStarredState() {
+    override fun fetchStarState() {
         cancel()
 
         job = scope.launch(Dispatchers.IO) {

--- a/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestImpl.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestImpl.kt
@@ -7,11 +7,11 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
-class StarRequest internal constructor(
+class StarStateRequestImpl internal constructor(
     private val starStateFetcher: StarStateFetcher,
     private val repoEntity: RepoEntity,
     private val scope: CoroutineScope,
-) : Request {
+) : StarStateRequest {
     private var job: Job? = null
 
     override fun checkStarredState() {

--- a/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestImpl.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/request/StarStateRequestImpl.kt
@@ -7,7 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 
-class StarStateRequestImpl internal constructor(
+internal class StarStateRequestImpl internal constructor(
     private val starStateFetcher: StarStateFetcher,
     private val repoEntity: RepoEntity,
     private val scope: CoroutineScope,

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -10,4 +10,6 @@ interface RepoRepository {
     suspend fun isStarred(repoName: String) : Result<Boolean>
 
     suspend fun starRepository(userName: String, repoName: String) : Result<Unit>
+
+    suspend fun unStarRepository(userName: String, repoName: String) : Result<Unit>
 }

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -8,4 +8,6 @@ interface RepoRepository {
     suspend fun getRepositories() : Flow<PagingData<RepoEntity>>
 
     suspend fun isStarred(repoName: String) : Result<Boolean>
+
+    suspend fun starRepository(userName: String, repoName: String) : Result<Unit>
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -51,5 +51,15 @@ internal class RepoRepositoryImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun unStarRepository(userName: String, repoName: String): Result<Unit> {
+        return try {
+            repoStarApiDataSource.unStarRepository(userName, repoName)
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -41,5 +41,15 @@ internal class RepoRepositoryImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun starRepository(userName: String, repoName: String): Result<Unit> {
+        return try {
+            repoStarApiDataSource.starRepository(userName, repoName)
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }
 

--- a/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
@@ -4,4 +4,6 @@ internal interface RepoStarApiDataSource {
     suspend fun checkRepositoryIsStarred(repoName: String) : Boolean
 
     suspend fun starRepository(userName: String, repoName: String)
+
+    suspend fun unStarRepository(userName: String, repoName: String)
 }

--- a/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
@@ -2,4 +2,6 @@ package com.prac.data.source
 
 internal interface RepoStarApiDataSource {
     suspend fun checkRepositoryIsStarred(repoName: String) : Boolean
+
+    suspend fun starRepository(userName: String, repoName: String)
 }

--- a/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
+++ b/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
@@ -3,6 +3,7 @@ package com.prac.data.source.api
 import com.prac.data.source.dto.RepoDto
 import retrofit2.Response
 import retrofit2.http.GET
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -17,6 +18,12 @@ internal interface GitHubApi {
 
     @GET("user/starred/{userName}/{repoName}")
     suspend fun checkRepositoryIsStarred(
+        @Path("userName") userName: String,
+        @Path("repoName") repoName: String
+    )
+
+    @PUT("user/starred/{userName}/{repoName}")
+    suspend fun starRepository(
         @Path("userName") userName: String,
         @Path("repoName") repoName: String
     )

--- a/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
+++ b/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
@@ -2,6 +2,7 @@ package com.prac.data.source.api
 
 import com.prac.data.source.dto.RepoDto
 import retrofit2.Response
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -24,6 +25,12 @@ internal interface GitHubApi {
 
     @PUT("user/starred/{userName}/{repoName}")
     suspend fun starRepository(
+        @Path("userName") userName: String,
+        @Path("repoName") repoName: String
+    )
+
+    @DELETE("user/starred/{userName}/{repoName}")
+    suspend fun unStarRepository(
         @Path("userName") userName: String,
         @Path("repoName") repoName: String
     )

--- a/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
@@ -19,4 +19,8 @@ internal class RepoStarApiDataSourceImpl @Inject constructor(
     override suspend fun starRepository(userName: String, repoName: String) {
         gitHubApi.starRepository(userName, repoName)
     }
+
+    override suspend fun unStarRepository(userName: String, repoName: String) {
+        gitHubApi.unStarRepository(userName, repoName)
+    }
 }

--- a/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
@@ -15,4 +15,8 @@ internal class RepoStarApiDataSourceImpl @Inject constructor(
             false
         }
     }
+
+    override suspend fun starRepository(userName: String, repoName: String) {
+        gitHubApi.starRepository(userName, repoName)
+    }
 }


### PR DESCRIPTION
notion - https://www.notion.so/refact-Request-ef089e119e234e648e4114d513340033?pvs=4

## AS-IS
```kotlin
interface Request {
    fun checkStarredState()
    fun cancel()
    fun isCompleted() : Boolean
}
``` 
```kotlin
class RequestBuilder @AssistedInject constructor(
    ....
)
``` 
```kotlin
class StarRequest internal constructor(
    ....
)
``` 
- `Request` 네이밍이 명확하지 않다.
- `checkStarredState` 함수명이 명확하지 않다.

## TO-BE
```kotlin
interface StarStateRequest {
    fun fetchStarState()
    fun cancel()
    fun isCompleted() : Boolean
}
``` 
```kotlin
class StarStateRequestBuilder @AssistedInject constructor(
    ....
)
``` 
```kotlin
internal class StarStateRequestImpl internal constructor(
    ....
)
``` 

- #62