### PR TITLE
feat: unStar API Data Module

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun unStar(repoEntity: RepoEntity) {
-            TODO("Not yet implemented")
+            mainViewModel.unStarRepository(repoEntity)
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -93,5 +93,9 @@ class MainActivity : AppCompatActivity() {
         override fun star(repoEntity: RepoEntity) {
             mainViewModel.starRepository(repoEntity)
         }
+
+        override fun unStar(repoEntity: RepoEntity) {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -106,5 +106,6 @@ class MainAdapter(
 
     interface StarClickListener {
         fun star(repoEntity: RepoEntity)
+        fun unStar(repoEntity: RepoEntity)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -77,7 +77,12 @@ class MainAdapter(
             starClickListener: StarClickListener
         ) {
             setOnClickListener {
-                if (repoEntity.isStarred == false) starClickListener.star(repoEntity)
+                if (repoEntity.isStarred == true) {
+                    starClickListener.unStar(repoEntity)
+                    return@setOnClickListener
+                }
+
+                starClickListener.star(repoEntity)
             }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -83,6 +83,27 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun unStarRepository(repoEntity: RepoEntity) {
+        starStateMediator.updateStarState(
+            id = repoEntity.id,
+            isStarred = false,
+            stargazersCount = repoEntity.stargazersCount - 1
+        )
+
+        viewModelScope.launch(Dispatchers.IO) {
+            repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    starStateMediator.updateStarState(
+                        id = repoEntity.id,
+                        isStarred = true,
+                        stargazersCount = repoEntity.stargazersCount
+                    )
+
+                    //TODO show alert dialog
+                }
+        }
+    }
+
     init {
         getRepositories()
     }

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -10,4 +10,6 @@ interface RepoRepository {
     suspend fun isStarred(repoName: String) : Result<Boolean>
 
     suspend fun starRepository(userName: String, repoName: String) : Result<Unit>
+
+    suspend fun unStarRepository(userName: String, repoName: String) : Result<Unit>
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -51,5 +51,15 @@ internal class RepoRepositoryImpl @Inject constructor(
             Result.failure(e)
         }
     }
+
+    override suspend fun unStarRepository(userName: String, repoName: String): Result<Unit> {
+        return try {
+            repoStarApiDataSource.unStarRepository(userName, repoName)
+
+            Result.success(Unit)
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 }
 

--- a/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/RepoStarApiDataSource.kt
@@ -4,4 +4,6 @@ internal interface RepoStarApiDataSource {
     suspend fun checkRepositoryIsStarred(repoName: String) : Boolean
 
     suspend fun starRepository(userName: String, repoName: String)
+
+    suspend fun unStarRepository(userName: String, repoName: String)
 }

--- a/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
+++ b/data/src/main/java/com/prac/data/source/api/GitHubApi.kt
@@ -2,6 +2,7 @@ package com.prac.data.source.api
 
 import com.prac.data.source.dto.RepoDto
 import retrofit2.Response
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PUT
 import retrofit2.http.Path
@@ -24,6 +25,12 @@ internal interface GitHubApi {
 
     @PUT("user/starred/{userName}/{repoName}")
     suspend fun starRepository(
+        @Path("userName") userName: String,
+        @Path("repoName") repoName: String
+    )
+
+    @DELETE("user/starred/{userName}/{repoName}")
+    suspend fun unStarRepository(
         @Path("userName") userName: String,
         @Path("repoName") repoName: String
     )

--- a/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/impl/RepoStarApiDataSourceImpl.kt
@@ -19,4 +19,8 @@ internal class RepoStarApiDataSourceImpl @Inject constructor(
     override suspend fun starRepository(userName: String, repoName: String) {
         gitHubApi.starRepository(userName, repoName)
     }
+
+    override suspend fun unStarRepository(userName: String, repoName: String) {
+        gitHubApi.unStarRepository(userName, repoName)
+    }
 }


### PR DESCRIPTION
notion - https://www.notion.so/feat-unStar-API-Data-Module-5e9895297ca546e48d3e639036308550?pvs=4

## AS-IS
- `service` 에서 unStar repository API 가 존재하지 않는다.
- `dataSource` 에서 `service` 의 unStar repository 메서드를 호출하기 위한 메서드가 존재하지 않는다.
- `Repository` 에서 `dataSource` 의 unStar repository 메서드를 호출하기 위한 메서드가 존재하지 않는다.

## TO-BE
- #66 