### PR TITLE
feat: Star Image View 클릭 시 unStar 상태 변경 기능 추가

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -95,7 +95,7 @@ class MainActivity : AppCompatActivity() {
         }
 
         override fun unStar(repoEntity: RepoEntity) {
-            TODO("Not yet implemented")
+            mainViewModel.unStarRepository(repoEntity)
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainActivity.kt
@@ -93,5 +93,9 @@ class MainActivity : AppCompatActivity() {
         override fun star(repoEntity: RepoEntity) {
             mainViewModel.starRepository(repoEntity)
         }
+
+        override fun unStar(repoEntity: RepoEntity) {
+            TODO("Not yet implemented")
+        }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -106,5 +106,6 @@ class MainAdapter(
 
     interface StarClickListener {
         fun star(repoEntity: RepoEntity)
+        fun unStar(repoEntity: RepoEntity)
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainAdapter.kt
@@ -77,7 +77,12 @@ class MainAdapter(
             starClickListener: StarClickListener
         ) {
             setOnClickListener {
-                if (repoEntity.isStarred == false) starClickListener.star(repoEntity)
+                if (repoEntity.isStarred == true) {
+                    starClickListener.unStar(repoEntity)
+                    return@setOnClickListener
+                }
+
+                starClickListener.star(repoEntity)
             }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -83,6 +83,27 @@ class MainViewModel @Inject constructor(
         }
     }
 
+    fun unStarRepository(repoEntity: RepoEntity) {
+        starStateMediator.updateStarState(
+            id = repoEntity.id,
+            isStarred = false,
+            stargazersCount = repoEntity.stargazersCount - 1
+        )
+
+        viewModelScope.launch(Dispatchers.IO) {
+            repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    starStateMediator.updateStarState(
+                        id = repoEntity.id,
+                        isStarred = true,
+                        stargazersCount = repoEntity.stargazersCount
+                    )
+
+                    //TODO show alert dialog
+                }
+        }
+    }
+
     init {
         getRepositories()
     }


### PR DESCRIPTION
notion - https://www.notion.so/feat-Star-Image-View-unStar-c8edb7f16c6b431491f67f62fc583997?pvs=4

## AS-IS
- `MainViewModel` 에서 비즈니스 로직이 존재하지 않는다.
- `StarClickListener` unStar 메서드가 존재하지 않는다.

## TO-BE
```kotlin
  fun unStarRepository(repoEntity: RepoEntity) {
      starStateMediator.updateStarState(
          id = repoEntity.id,
          isStarred = false,
          stargazersCount = repoEntity.stargazersCount - 1
      )

      viewModelScope.launch(Dispatchers.IO) {
          repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
              .onFailure {
                  starStateMediator.updateStarState(
                      id = repoEntity.id,
                      isStarred = true,
                      stargazersCount = repoEntity.stargazersCount
                  )

                  //TODO show alert dialog
              }
      }
  }
```
- `MainViewModel` 에서 비즈니스 로직 호출
- 낙관적 업데이트를 위해서 성공 여부와 상관없이 StarState 를 변경한다.

```kotlin
interface StarClickListener {
    fun star(repoEntity: RepoEntity)
    fun unStar(repoEntity: RepoEntity)
}
```
- `MainAdapter` 에서 `unStar` 메서드 추가

```kotlin
private class StarClickListenerImpl(
     private val mainViewModel: MainViewModel
) : MainAdapter.StarClickListener {
    override fun star(repoEntity: RepoEntity) {
        mainViewModel.starRepository(repoEntity)
    }
    override fun unStar(repoEntity: RepoEntity) {
        mainViewModel.unStarRepository(repoEntity)
    }
}
```
- `StarClickListenerImpl` 에서 `unStar` 메서드 구현