### PR TITLE
feat: Star API 네트워크 연결 실패 시 WorkManager 를 통해서 작업 등록 및 재시도 구현

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -79,4 +79,9 @@ dependencies {
     implementation(libs.androidx.lifecycle.runtime)
 
     implementation(libs.androidx.paging)
+
+    implementation(libs.androidx.hilt.common)
+    implementation(libs.androidx.hilt.work)
+    implementation(libs.androidx.work.runtime)
+    kapt(libs.androidx.hilt.compiler)
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -41,6 +41,11 @@
         <activity
             android:name=".main.detail.DetailActivity"
             android:exported="false"/>
+        <provider
+            android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
+            tools:node="remove">
+        </provider>
     </application>
 
 </manifest>

--- a/app/src/main/java/com/prac/githubrepo/GitHubApplication.kt
+++ b/app/src/main/java/com/prac/githubrepo/GitHubApplication.kt
@@ -1,9 +1,19 @@
 package com.prac.githubrepo
 
 import android.app.Application
+import androidx.hilt.work.HiltWorkerFactory
+import androidx.work.Configuration
 import dagger.hilt.android.HiltAndroidApp
+import javax.inject.Inject
 
 @HiltAndroidApp
-class GitHubApplication : Application() {
+class GitHubApplication : Application(), Configuration.Provider {
 
+    @Inject
+    lateinit var workerFactory: HiltWorkerFactory
+
+    override val workManagerConfiguration: Configuration
+        get() = Configuration.Builder()
+            .setWorkerFactory(workerFactory)
+            .build()
 }

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -10,6 +10,7 @@ import androidx.paging.map
 import com.prac.data.entity.RepoEntity
 import com.prac.data.exception.GitHubApiException
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.work.StarWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
@@ -21,12 +22,14 @@ import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
     private val repoRepository: RepoRepository,
-    private val starStateMediator: StarStateMediator
+    private val starStateMediator: StarStateMediator,
+    private val starWorkManager: StarWorkManager
 ): ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -79,13 +82,19 @@ class MainViewModel @Inject constructor(
         viewModelScope.launch(Dispatchers.IO) {
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
                 .onFailure {
-                    starStateMediator.updateStarState(
-                        id = repoEntity.id,
-                        isStarred = false,
-                        stargazersCount = repoEntity.stargazersCount
-                    )
-
-                    //TODO show alert dialog
+                    when (it) {
+                        is IOException -> {
+                            starWorkManager.enqueueStarWorker(
+                                repoEntity.id.toString(),
+                                repoEntity.owner.login,
+                                repoEntity.name
+                            )
+                        }
+                        else -> {
+                            // 레포지토리가 사라진 경우, 레파지토리 및 사용자 명이 바뀐 경우
+                            // TODO show alert dialog and Refresh PagingData
+                        }
+                    }
                 }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import androidx.work.Constraints
 import androidx.work.NetworkType
 import androidx.work.WorkManager
+import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.work.StarWorkManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -26,5 +28,14 @@ class WorkModule {
         return Constraints.Builder()
             .setRequiredNetworkType(NetworkType.CONNECTED)
             .build()
+    }
+
+    @Provides
+    fun provideStarRequest(repoRepository: RepoRepository) : StarWorkManager.StarWorker.StarRequest {
+        return object : StarWorkManager.StarWorker.StarRequest {
+            override suspend fun starRepository(userName: String, repoName: String) {
+                repoRepository.starRepository(userName, repoName)
+            }
+        }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
@@ -1,6 +1,8 @@
 package com.prac.githubrepo.main.di
 
 import android.content.Context
+import androidx.work.Constraints
+import androidx.work.NetworkType
 import androidx.work.WorkManager
 import dagger.Module
 import dagger.Provides
@@ -16,5 +18,13 @@ class WorkModule {
     @Singleton
     fun provideWorkManager(@ApplicationContext context: Context): WorkManager {
         return WorkManager.getInstance(context)
+    }
+
+    @Provides
+    @Singleton
+    fun provideConstraints(): Constraints {
+        return Constraints.Builder()
+            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .build()
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
@@ -1,0 +1,20 @@
+package com.prac.githubrepo.main.di
+
+import android.content.Context
+import androidx.work.WorkManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class WorkModule {
+    @Provides
+    @Singleton
+    fun provideWorkManager(@ApplicationContext context: Context): WorkManager {
+        return WorkManager.getInstance(context)
+    }
+}

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -1,7 +1,13 @@
 package com.prac.githubrepo.main.work
 
+import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
+import androidx.work.CoroutineWorker
 import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,4 +16,14 @@ class StarWorkManager @Inject constructor(
     private val workManager: WorkManager,
     private val constraints: Constraints
 ) {
+    @HiltWorker
+    class StarWorker @AssistedInject constructor(
+        @Assisted private val context: Context,
+        @Assisted private val params: WorkerParameters,
+    ) : CoroutineWorker(context, params) {
+        override suspend fun doWork(): Result {
+            // TODO doWork
+            return Result.success()
+        }
+    }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -4,10 +4,14 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,6 +20,29 @@ class StarWorkManager @Inject constructor(
     private val workManager: WorkManager,
     private val constraints: Constraints
 ) {
+
+    /**
+     * delay 시간이 30초, 60초, 120초인 [OneTimeWorkRequest] 리스트를 생성하는 메서드
+     * 리스트의 사이즈는 3개로 고정되어 있음.
+     */
+    private fun makeWorkRequestList(data: Data) : List<OneTimeWorkRequest> {
+        return ArrayList<OneTimeWorkRequest>(3).apply {
+            var delaySeconds = 30L
+
+            for (i in 1..3) {
+                add(
+                    OneTimeWorkRequestBuilder<StarWorker>()
+                        .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
+                        .setConstraints(constraints)
+                        .setInputData(data)
+                        .build()
+                )
+
+                delaySeconds *= 2
+            }
+        }
+    }
+
     @HiltWorker
     class StarWorker @AssistedInject constructor(
         @Assisted private val context: Context,

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -22,8 +22,20 @@ class StarWorkManager @Inject constructor(
         @Assisted private val params: WorkerParameters,
         private val starRequest: StarRequest
     ) : CoroutineWorker(context, params) {
+
+        companion object {
+            const val KEY_USER_NAME = "userName"
+            const val KEY_REPO_NAME = "repoName"
+        }
+
         override suspend fun doWork(): Result {
-            // TODO doWork
+            val userName = params.inputData.getString(KEY_USER_NAME)
+            val repoName = params.inputData.getString(KEY_REPO_NAME)
+
+            if (userName == null || repoName == null) return Result.failure()
+
+            starRequest.starRepository(userName, repoName)
+
             return Result.success()
         }
 

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -1,0 +1,13 @@
+package com.prac.githubrepo.main.work
+
+import androidx.work.Constraints
+import androidx.work.WorkManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class StarWorkManager @Inject constructor(
+    private val workManager: WorkManager,
+    private val constraints: Constraints
+) {
+}

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -5,10 +5,13 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.prac.githubrepo.main.work.StarWorkManager.StarWorker.Companion.KEY_REPO_NAME
+import com.prac.githubrepo.main.work.StarWorkManager.StarWorker.Companion.KEY_USER_NAME
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
@@ -20,6 +23,23 @@ class StarWorkManager @Inject constructor(
     private val workManager: WorkManager,
     private val constraints: Constraints
 ) {
+
+    fun enqueueStarWorker(id: String, userName: String, repoName: String) {
+        val data = Data.Builder()
+            .putString(KEY_USER_NAME, userName)
+            .putString(KEY_REPO_NAME, repoName)
+            .build()
+
+        val workRequestList = makeWorkRequestList(data)
+
+        workManager.beginUniqueWork(
+            id,
+            ExistingWorkPolicy.REPLACE,
+            workRequestList[0]
+        ).then(workRequestList[1])
+            .then(workRequestList[2])
+            .enqueue()
+    }
 
     /**
      * delay 시간이 30초, 60초, 120초인 [OneTimeWorkRequest] 리스트를 생성하는 메서드

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -20,10 +20,15 @@ class StarWorkManager @Inject constructor(
     class StarWorker @AssistedInject constructor(
         @Assisted private val context: Context,
         @Assisted private val params: WorkerParameters,
+        private val starRequest: StarRequest
     ) : CoroutineWorker(context, params) {
         override suspend fun doWork(): Result {
             // TODO doWork
             return Result.success()
+        }
+
+        interface StarRequest {
+            suspend fun starRepository(userName: String, repoName: String)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,10 @@ datastore = "1.0.0"
 datastore-preferences = "1.0.0"
 protobuf-javalite = "3.18.0"
 paging = "3.3.1"
+hiltCommon = "1.2.0"
+hiltWork = "1.2.0"
+workRuntime = "2.9.1"
+hiltCompiler = "1.0.0"
 
 # plugins
 kapt = "1.5.30"
@@ -57,6 +61,10 @@ androidx-datastore = { group = "androidx.datastore", name = "datastore", version
 androidx-datastore-preferences = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "datastore-preferences" }
 protobuf = { group = "com.google.protobuf", name = "protobuf-javalite", version.ref = "protobuf-javalite" }
 androidx-paging = { group = "androidx.paging", name = "paging-runtime", version.ref = "paging" }
+androidx-hilt-common = { group = "androidx.hilt", name = "hilt-common", version.ref = "hiltCommon" }
+androidx-hilt-work = { group = "androidx.hilt", name = "hilt-work", version.ref = "hiltWork" }
+androidx-work-runtime = { group = "androidx.work", name = "work-runtime-ktx", version.ref = "workRuntime" }
+androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", version.ref = "hiltCompiler" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
notion - https://www.notion.so/feat-Star-API-WorkManager-0b1aeb33b05148c9ada63759a2350d26?pvs=4

# AS-IS
- 현재 Star API call 네트워크 연결 실패했을 때 재시도를 하고 있지 않다. 단순히 UI 만 수정하고 있다.
- 앱이 백그라운드로 전환되거나 종료되었을 때 작업을 수행할 수 있는 구조가 아니다.

# TO-BE

```kotlin
class StarWorker(
    ....,
    private val starRequest: StarRequest
) : CoroutineWorker() {

    override suspend fun doWork() {
        starRequest.starRepository()
    }
    
    // 구현체에서 RepoRepository 의존성 주입 
    interface StarRequest {
        suspend fun starRepository(userName: String, repoName: String)
    }
}
```

- `CoroutineWorker` 를 구현한 `StarWorker` 클래스 생성

```kotlin
class StarWorkManager(
    private workManager: WorkManager,
    ....
) {
    // WorkManager 에 작업 체이닝을 설정하는 메서드
    fun enqueueStarWorker() {
        // 작업 체이닝을 위한 OneTimeWorkRequest List 변수 생성 
        val oneTimeWorkRequestList
        
        // WorkManager 에 작업 체이닝
        // 기존에 존재하는 작업을 제거한다.
        // 예를 들어, 네트워크가 꺼진 상태에서 
        // Star - UnStar(아직 미구현) - Star 을 한다면 workManager 에는 Star Worker 만 존재한다.
        workManager.beginUniqueWork(
            ExistingWorkPolicy.REPLACE,
            oneTimeWorkRequestList[0]
        )
          .then(oneTimeWorkRequestList[1])
          .then(oneTimeWorkRequestList[2])
    }
    
    class StarWorker() {
		    ....
    } : CoroutineWorker() {
		    ....
    }
}
```

- Singleton 으로 제공되는 `WorkManager` 를 관리하기 위한 클래스 생성

```kotlin
starWorkManager.enqueueStarWorker(
    id,
    userName,
    repoName
)
```

- Star API 를 사용하는 `MainViewModel`, `DetailViewModel` 에서 API 가 IOException 일 때 다음과 같은 로직 추가

- #75 