### PR TITLE
feat: unStar API 네트워크 연결 실패 시 WorkManager 를 통해서 작업 등록 및 재시도 구현

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/WorkModule.kt
@@ -6,6 +6,7 @@ import androidx.work.NetworkType
 import androidx.work.WorkManager
 import com.prac.data.repository.RepoRepository
 import com.prac.githubrepo.main.work.StarWorkManager
+import com.prac.githubrepo.main.work.UnStarWorkManager
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -35,6 +36,15 @@ class WorkModule {
         return object : StarWorkManager.StarWorker.StarRequest {
             override suspend fun starRepository(userName: String, repoName: String) {
                 repoRepository.starRepository(userName, repoName)
+            }
+        }
+    }
+
+    @Provides
+    fun provideUnStarRequest(repoRepository: RepoRepository) : UnStarWorkManager.UnStarWorker.UnStarRequest {
+        return object : UnStarWorkManager.UnStarWorker.UnStarRequest {
+            override suspend fun unStarRepository(userName: String, repoName: String) {
+                repoRepository.unStarRepository(userName, repoName)
             }
         }
     }

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -1,0 +1,13 @@
+package com.prac.githubrepo.main.work
+
+import androidx.work.Constraints
+import androidx.work.WorkManager
+import javax.inject.Inject
+import javax.inject.Singleton
+
+@Singleton
+class UnStarWorkManager @Inject constructor(
+    private val workManager: WorkManager,
+    private val constraints: Constraints
+) {
+}

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -4,10 +4,14 @@ import android.content.Context
 import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequest
+import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
+import java.util.concurrent.TimeUnit
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -16,6 +20,29 @@ class UnStarWorkManager @Inject constructor(
     private val workManager: WorkManager,
     private val constraints: Constraints
 ) {
+
+    /**
+     * delay 시간이 30초, 60초, 120초인 [OneTimeWorkRequest] 리스트를 생성하는 메서드
+     * 리스트의 사이즈는 3개로 고정되어 있음.
+     */
+    private fun makeWorkRequestList(data: Data) : List<OneTimeWorkRequest> {
+        return ArrayList<OneTimeWorkRequest>(3).apply {
+            var delaySeconds = 30L
+
+            for (i in 1..3) {
+                add(
+                    OneTimeWorkRequestBuilder<UnStarWorker>()
+                        .setInitialDelay(delaySeconds, TimeUnit.SECONDS)
+                        .setConstraints(constraints)
+                        .setInputData(data)
+                        .build()
+                )
+
+                delaySeconds *= 2
+            }
+        }
+    }
+
     @HiltWorker
     class UnStarWorker @AssistedInject constructor(
         @Assisted private val context: Context,

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -22,8 +22,20 @@ class UnStarWorkManager @Inject constructor(
         @Assisted private val params: WorkerParameters,
         private val unStarRequest: UnStarRequest
     ) : CoroutineWorker(context, params) {
+
+        companion object {
+            const val KEY_USER_NAME = "userName"
+            const val KEY_REPO_NAME = "repoName"
+        }
+
         override suspend fun doWork(): Result {
-            // TODO doWork
+            val userName = params.inputData.getString(KEY_USER_NAME)
+            val repoName = params.inputData.getString(KEY_REPO_NAME)
+
+            if (userName == null || repoName == null) return Result.failure()
+
+            unStarRequest.unStarRepository(userName, repoName)
+
             return Result.success()
         }
 

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -1,7 +1,13 @@
 package com.prac.githubrepo.main.work
 
+import android.content.Context
+import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
+import androidx.work.CoroutineWorker
 import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -10,4 +16,14 @@ class UnStarWorkManager @Inject constructor(
     private val workManager: WorkManager,
     private val constraints: Constraints
 ) {
+    @HiltWorker
+    class UnStarWorker @AssistedInject constructor(
+        @Assisted private val context: Context,
+        @Assisted private val params: WorkerParameters,
+    ) : CoroutineWorker(context, params) {
+        override suspend fun doWork(): Result {
+            // TODO doWork
+            return Result.success()
+        }
+    }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -20,10 +20,15 @@ class UnStarWorkManager @Inject constructor(
     class UnStarWorker @AssistedInject constructor(
         @Assisted private val context: Context,
         @Assisted private val params: WorkerParameters,
+        private val unStarRequest: UnStarRequest
     ) : CoroutineWorker(context, params) {
         override suspend fun doWork(): Result {
             // TODO doWork
             return Result.success()
+        }
+
+        interface UnStarRequest {
+            suspend fun unStarRepository(userName: String, repoName: String)
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -5,10 +5,13 @@ import androidx.hilt.work.HiltWorker
 import androidx.work.Constraints
 import androidx.work.CoroutineWorker
 import androidx.work.Data
+import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.OneTimeWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.WorkerParameters
+import com.prac.githubrepo.main.work.UnStarWorkManager.UnStarWorker.Companion.KEY_REPO_NAME
+import com.prac.githubrepo.main.work.UnStarWorkManager.UnStarWorker.Companion.KEY_USER_NAME
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
@@ -20,6 +23,23 @@ class UnStarWorkManager @Inject constructor(
     private val workManager: WorkManager,
     private val constraints: Constraints
 ) {
+
+    fun enqueueUnStarWorker(id: String, userName: String, repoName: String) {
+        val data = Data.Builder()
+            .putString(KEY_USER_NAME, userName)
+            .putString(KEY_REPO_NAME, repoName)
+            .build()
+
+        val workRequestList = makeWorkRequestList(data)
+
+        workManager.beginUniqueWork(
+            id,
+            ExistingWorkPolicy.REPLACE,
+            workRequestList[0]
+        ).then(workRequestList[1])
+            .then(workRequestList[2])
+            .enqueue()
+    }
 
     /**
      * delay 시간이 30초, 60초, 120초인 [OneTimeWorkRequest] 리스트를 생성하는 메서드


### PR DESCRIPTION
notion - https://www.notion.so/feat-unStar-API-WorkManager-8de86e4d3d0c40979124274c19ccae55?pvs=4

# AS-IS
- 현재 UnStar API call 네트워크 연결 실패했을 때 재시도를 하고 있지 않다. 단순히 UI 만 수정하고 있다.
- 앱이 백그라운드로 전환되거나 종료되었을 때 작업을 수행할 수 있는 구조가 아니다.

# TO-BE

```kotlin
class UnStarWorker(
    ....,
    private val unStarRequest: UnStarRequest
) : CoroutineWorker() {

    override suspend fun doWork() {
        unStarRequest.unStarRepository()
    }
    
    // 구현체에서 RepoRepository 의존성 주입 
    interface UnStarRequest {
        suspend fun unStarRepository(userName: String, repoName: String)
    }
}
```

- `CoroutineWorker` 를 구현한 `StarWorker` 클래스 생성

```kotlin
class UnStarWorkManager(
    private workManager: WorkManager,
    ....
) {
    // WorkManager 에 작업 체이닝을 설정하는 메서드
    fun enqueueStarWorker() {
        // 작업 체이닝을 위한 OneTimeWorkRequest List 변수 생성 
        val oneTimeWorkRequestList
        
        // WorkManager 에 작업 체이닝
        // 기존에 존재하는 작업을 제거한다.
        // 예를 들어, 네트워크가 꺼진 상태에서 
        // UnStar - Star - UnStar 을 한다면 workManager 에는 UnStar Worker 만 존재한다.
        workManager.beginUniqueWork(
            ExistingWorkPolicy.REPLACE,
            oneTimeWorkRequestList[0]
        )
          .then(oneTimeWorkRequestList[1])
          .then(oneTimeWorkRequestList[2])
    }
    
    class UnStarWorker() {
		    ....
    } : CoroutineWorker() {
		    ....
    }
}
```

- Singleton 으로 제공되는 `WorkManager` 를 관리하기 위한 클래스 생성

```kotlin
unStarWorkManager.enqueueUnStarWorker(
    id,
    userName,
    repoName
)
```

- UnStar API 를 사용하는 `MainViewModel`, `DetailViewModel` 에서 API 가 IOException 일 때 다음과 같은 로직 추가

- #76 