### PR TITLE
feat: WorkManager 에 Work 를 등록하기 전 Cancel 메서드 추가

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -83,7 +83,9 @@ class MainViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.IO) {
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
-                .onFailure {
+                .onSuccess {
+                    starWorkManager.cancelStarWorker(repoEntity.id.toString())
+                }.onFailure {
                     when (it) {
                         is IOException -> {
                             starWorkManager.enqueueStarWorker(

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -112,7 +112,9 @@ class MainViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.IO) {
             repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
-                .onFailure {
+                .onSuccess {
+                    unStarWorkManager.cancelUnStarWorker(repoEntity.id.toString())
+                }.onFailure {
                     when (it) {
                         is IOException -> {
                             unStarWorkManager.enqueueUnStarWorker(

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -130,7 +130,9 @@ class DetailViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.IO) {
             repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
-                .onFailure {
+                .onSuccess {
+                    unStarWorkManager.cancelUnStarWorker(repoDetailEntity.id.toString())
+                }.onFailure {
                     when (it) {
                         is IOException -> {
                             unStarWorkManager.enqueueUnStarWorker(

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -101,7 +101,9 @@ class DetailViewModel @Inject constructor(
 
         viewModelScope.launch(Dispatchers.IO) {
             repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
-                .onFailure {
+                .onSuccess {
+                    starWorkManager.cancelStarWorker(repoDetailEntity.id.toString())
+                }.onFailure {
                     when (it) {
                         is IOException -> {
                             starWorkManager.enqueueStarWorker(

--- a/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/StarWorkManager.kt
@@ -41,6 +41,10 @@ class StarWorkManager @Inject constructor(
             .enqueue()
     }
 
+    fun cancelStarWorker(id: String) {
+        workManager.cancelUniqueWork(id)
+    }
+
     /**
      * delay 시간이 30초, 60초, 120초인 [OneTimeWorkRequest] 리스트를 생성하는 메서드
      * 리스트의 사이즈는 3개로 고정되어 있음.

--- a/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/work/UnStarWorkManager.kt
@@ -41,6 +41,10 @@ class UnStarWorkManager @Inject constructor(
             .enqueue()
     }
 
+    fun cancelUnStarWorker(id: String) {
+        workManager.cancelUniqueWork(id)
+    }
+
     /**
      * delay 시간이 30초, 60초, 120초인 [OneTimeWorkRequest] 리스트를 생성하는 메서드
      * 리스트의 사이즈는 3개로 고정되어 있음.


### PR DESCRIPTION
notion - https://www.notion.so/feat-WorkManager-Work-Cancel-cb06528912e343d895c52cfb1b01ec7d?pvs=4

# AS-IS
- 현재 작업을 등록하기 전에 `WorkManager` 에 Cancel 메서드를 수행하고 있지 않다.
- Cancel 메서드를 호출하지 않아 발생할 수 있는 문제는 다음과 같다.
    
    사용자 네트워크가 불안정한 상태로 인해 Star Work 등록 → 네트워크 연결이 완료되고 Unstar → 30초 후 Star Work 시작 
    

# TO-BE

```kotlin
fun cancelUnStarWorker(id: String) {
	  workManager.cancelUniqueWork(id)
}
```

- Star api call, UnStar api call 이 성공일 경우 WorkManager 에 Work 를 취소

- #77 