### PR TITLE
refact: PagingSource 에서 RemoteMediator 로 변경

### DIFF
--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -1,18 +1,22 @@
 package com.prac.data.repository
 
+import androidx.paging.ExperimentalPagingApi
 import androidx.paging.PagingData
+import androidx.paging.RemoteMediator
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
+import com.prac.data.source.local.room.entity.Repository
 import kotlinx.coroutines.flow.Flow
 
-interface RepoRepository {
-    suspend fun getRepositories() : Flow<PagingData<RepoEntity>>
+@OptIn(ExperimentalPagingApi::class)
+abstract class RepoRepository : RemoteMediator<Int, Repository>() {
+    abstract suspend fun getRepositories() : Flow<PagingData<RepoEntity>>
 
-    suspend fun getRepository(userName: String, repoName: String) : Result<RepoDetailEntity>
+    abstract suspend fun getRepository(userName: String, repoName: String) : Result<RepoDetailEntity>
 
-    suspend fun isStarred(repoName: String) : Result<Boolean>
+    abstract suspend fun isStarred(repoName: String) : Result<Boolean>
 
-    suspend fun starRepository(userName: String, repoName: String) : Result<Unit>
+    abstract suspend fun starRepository(userName: String, repoName: String) : Result<Unit>
 
-    suspend fun unStarRepository(userName: String, repoName: String) : Result<Unit>
+    abstract suspend fun unStarRepository(userName: String, repoName: String) : Result<Unit>
 }

--- a/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
+++ b/data/src/main/java/com/prac/data/repository/di/RepositoryModule.kt
@@ -8,6 +8,7 @@ import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
 import com.prac.data.source.network.TokenApiDataSource
 import com.prac.data.source.local.TokenLocalDataSource
+import com.prac.data.source.local.room.database.RepositoryDatabase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -28,7 +29,8 @@ internal class RepositoryModule {
     @Provides
     fun provideRepoRepository(
         repoApiDataSource: RepoApiDataSource,
-        repoStarApiDataSource: RepoStarApiDataSource
+        repoStarApiDataSource: RepoStarApiDataSource,
+        repositoryDatabase: RepositoryDatabase
     ): RepoRepository =
-        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource)
+        RepoRepositoryImpl(repoApiDataSource, repoStarApiDataSource, repositoryDatabase)
 }

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -12,6 +12,7 @@ import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
 import com.prac.data.source.local.room.database.RepositoryDatabase
+import com.prac.data.source.local.room.entity.RemoteKey
 import com.prac.data.source.local.room.entity.Repository
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
@@ -89,6 +90,14 @@ internal class RepoRepositoryImpl @Inject constructor(
     @OptIn(ExperimentalPagingApi::class)
     override suspend fun load(loadType: LoadType, state: PagingState<Int, Repository>): MediatorResult {
         TODO("Not yet implemented")
+    }
+
+    private suspend fun getRemoteKeyClosestToCurrentPosition(state: PagingState<Int, Repository>): RemoteKey? {
+        return state.anchorPosition?.let { position ->
+            state.closestItemToPosition(position)?.id?.let { repoId ->
+                repositoryDatabase.remoteKeyDao().remoteKey(repoId)
+            }
+        }
     }
 
     companion object {

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -100,6 +100,13 @@ internal class RepoRepositoryImpl @Inject constructor(
         }
     }
 
+    private suspend fun getRemoteKeyForFirstItem(state: PagingState<Int, Repository>): RemoteKey? {
+        return state.pages.firstOrNull { it.data.isNotEmpty() }?.data?.firstOrNull()
+            ?.let { repo ->
+                repositoryDatabase.remoteKeyDao().remoteKey(repo.id)
+            }
+    }
+
     companion object {
         private const val STARTING_PAGE_INDEX = 1
         private const val PAGE_SIZE = 10

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -74,5 +74,10 @@ internal class RepoRepositoryImpl @Inject constructor(
     override suspend fun load(loadType: LoadType, state: PagingState<Int, Repository>): MediatorResult {
         TODO("Not yet implemented")
     }
+
+    companion object {
+        private const val STARTING_PAGE_INDEX = 1
+        private const val PAGE_SIZE = 10
+    }
 }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -89,6 +89,25 @@ internal class RepoRepositoryImpl @Inject constructor(
 
     @OptIn(ExperimentalPagingApi::class)
     override suspend fun load(loadType: LoadType, state: PagingState<Int, Repository>): MediatorResult {
+        val page: Int = when (loadType) {
+            LoadType.REFRESH -> {
+                val remoteKeys = getRemoteKeyClosestToCurrentPosition(state)
+                remoteKeys?.nextKey?.minus(1) ?: STARTING_PAGE_INDEX
+            }
+            LoadType.PREPEND -> {
+                val remoteKeys = getRemoteKeyForFirstItem(state)
+                val prevKey = remoteKeys?.prevKey
+                    ?: return MediatorResult.Success(endOfPaginationReached = remoteKeys != null)
+                prevKey
+            }
+            LoadType.APPEND -> {
+                val remoteKeys = getRemoteKeyForLastItem(state)
+                val nextKey = remoteKeys?.nextKey
+                    ?: return MediatorResult.Success(endOfPaginationReached = remoteKeys != null)
+                nextKey
+            }
+        }
+
         TODO("Not yet implemented")
     }
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.data.source.local.room.database.RepositoryDatabase
 import com.prac.data.source.local.room.entity.Repository
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
@@ -20,7 +21,8 @@ import javax.inject.Inject
 
 internal class RepoRepositoryImpl @Inject constructor(
     private val repoApiDataSource: RepoApiDataSource,
-    private val repoStarApiDataSource: RepoStarApiDataSource
+    private val repoStarApiDataSource: RepoStarApiDataSource,
+    private val repositoryDatabase: RepositoryDatabase
 ) : RepoRepository() {
     override suspend fun getRepositories(): Flow<PagingData<RepoEntity>> {
         TODO()

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -14,7 +14,6 @@ import com.prac.data.repository.RepoRepository
 import com.prac.data.source.local.room.entity.Repository
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
-import com.prac.data.source.network.impl.RepoApiDataSourceImpl.Companion.PAGE_SIZE
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -23,19 +22,9 @@ internal class RepoRepositoryImpl @Inject constructor(
     private val repoApiDataSource: RepoApiDataSource,
     private val repoStarApiDataSource: RepoStarApiDataSource
 ) : RepoRepository() {
-    override suspend fun getRepositories(): Flow<PagingData<RepoEntity>> =
-        Pager(
-            config = PagingConfig(
-                pageSize = PAGE_SIZE,
-                enablePlaceholders = false
-            ),
-            pagingSourceFactory = { repoApiDataSource }
-        ).flow
-            .map { pagingData ->
-                pagingData.map { repoModel ->
-                    RepoEntity(repoModel.id, repoModel.name, OwnerEntity(repoModel.owner.login, repoModel.owner.avatarUrl), repoModel.stargazersCount, repoModel.updatedAt, null)
-                }
-            }
+    override suspend fun getRepositories(): Flow<PagingData<RepoEntity>> {
+        TODO()
+    }
 
     override suspend fun getRepository(userName: String, repoName: String): Result<RepoDetailEntity> {
         return try {

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -107,6 +107,13 @@ internal class RepoRepositoryImpl @Inject constructor(
             }
     }
 
+    private suspend fun getRemoteKeyForLastItem(state: PagingState<Int, Repository>): RemoteKey? {
+        return state.pages.lastOrNull { it.data.isNotEmpty() }?.data?.lastOrNull()
+            ?.let { repo ->
+                repositoryDatabase.remoteKeyDao().remoteKey(repo.id)
+            }
+    }
+
     companion object {
         private const val STARTING_PAGE_INDEX = 1
         private const val PAGE_SIZE = 10

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -1,13 +1,17 @@
 package com.prac.data.repository.impl
 
+import androidx.paging.ExperimentalPagingApi
+import androidx.paging.LoadType
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
+import androidx.paging.PagingState
 import androidx.paging.map
 import com.prac.data.entity.OwnerEntity
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.entity.RepoEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.data.source.local.room.entity.Repository
 import com.prac.data.source.network.RepoApiDataSource
 import com.prac.data.source.network.RepoStarApiDataSource
 import com.prac.data.source.network.impl.RepoApiDataSourceImpl.Companion.PAGE_SIZE
@@ -18,7 +22,7 @@ import javax.inject.Inject
 internal class RepoRepositoryImpl @Inject constructor(
     private val repoApiDataSource: RepoApiDataSource,
     private val repoStarApiDataSource: RepoStarApiDataSource
-) : RepoRepository {
+) : RepoRepository() {
     override suspend fun getRepositories(): Flow<PagingData<RepoEntity>> =
         Pager(
             config = PagingConfig(
@@ -75,6 +79,11 @@ internal class RepoRepositoryImpl @Inject constructor(
         } catch (e: Exception) {
             Result.failure(e)
         }
+    }
+
+    @OptIn(ExperimentalPagingApi::class)
+    override suspend fun load(loadType: LoadType, state: PagingState<Int, Repository>): MediatorResult {
+        TODO("Not yet implemented")
     }
 }
 

--- a/data/src/main/java/com/prac/data/source/network/RepoApiDataSource.kt
+++ b/data/src/main/java/com/prac/data/source/network/RepoApiDataSource.kt
@@ -1,14 +1,10 @@
 package com.prac.data.source.network
 
-import androidx.paging.PagingSource
-import androidx.paging.PagingState
 import com.prac.data.repository.model.RepoDetailModel
 import com.prac.data.repository.model.RepoModel
 
-internal abstract class RepoApiDataSource : PagingSource<Int, RepoModel>() {
-    abstract override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RepoModel>
+internal interface RepoApiDataSource {
+    suspend fun getRepositories(userName: String, perPage:Int, page: Int) : List<RepoModel>
 
-    abstract override fun getRefreshKey(state: PagingState<Int, RepoModel>): Int?
-
-    abstract suspend fun getRepository(userName: String, repoName: String) : RepoDetailModel
+    suspend fun getRepository(userName: String, repoName: String) : RepoDetailModel
 }

--- a/data/src/main/java/com/prac/data/source/network/impl/RepoApiDataSourceImpl.kt
+++ b/data/src/main/java/com/prac/data/source/network/impl/RepoApiDataSourceImpl.kt
@@ -10,40 +10,12 @@ import javax.inject.Inject
 
 internal class RepoApiDataSourceImpl @Inject constructor(
     private val gitHubService: GitHubService
-) : RepoApiDataSource() {
-    companion object {
-        const val STARTING_PAGE_INDEX = 1
-        const val PAGE_SIZE = 10
-    }
+) : RepoApiDataSource {
+    override suspend fun getRepositories(userName: String, perPage: Int, page: Int): List<RepoModel> {
+        val response = gitHubService.getRepos(userName, perPage, page)
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, RepoModel> {
-        try {
-            val position = params.key ?: STARTING_PAGE_INDEX
-
-            val response = gitHubService.getRepos("GongDoMin", params.loadSize, position)
-
-            val nextKey = if (response.size < PAGE_SIZE) {
-                null
-            } else {
-                position + (params.loadSize / PAGE_SIZE)
-            }
-
-            return LoadResult.Page(
-                data = response.map {
-                    RepoModel(it.id, it.name, OwnerModel(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt)
-                },
-                prevKey = if (position == STARTING_PAGE_INDEX) null else position - 1,
-                nextKey = nextKey
-            )
-        } catch (e: Exception) {
-            return LoadResult.Error(e)
-        }
-    }
-
-    override fun getRefreshKey(state: PagingState<Int, RepoModel>): Int? {
-        return state.anchorPosition?.let { anchorPosition ->
-            state.closestPageToPosition(anchorPosition)?.prevKey?.plus(1)
-                ?: state.closestPageToPosition(anchorPosition)?.nextKey?.minus(1)
+        return response.map {
+            RepoModel(it.id, it.name, OwnerModel(it.owner.login, it.owner.avatarUrl), it.stargazersCount, it.updatedAt)
         }
     }
 


### PR DESCRIPTION
notion - https://www.notion.so/refact-PagingSource-RemoteMediator-4fde44467b9d42e59a5e8d52bc4aa411?pvs=4

# AS-IS
- 현재 PagingSource 를 통해서 PagingData 를 제공해주고 있다. 이는 사용자가 오프라인이거나 네트워크가 불안정할 때 앱에서 아무것도 보여주지 못한다. 이를 해결하기 위해 내부 저장소를 사용하는 RemoteMediator 로 변경을 통해서 향상된 UX 를 제공하고자 한다.

# TO-BE
```mermaid
sequenceDiagram 
	participant ViewModel
	participant RepoRepository as RepoRepository(RemoteMediator)
	participant RepoDataSource
	participant RepoDatabase
  
  ViewModel ->> RepoRepository: pagingData 요청
  note over RepoRepository: load 메서드 시작
  RepoRepository ->> RepoDataSource: repository list 요청
  RepoDataSource ->> RepoRepository: repository list
  RepoRepository ->> RepoDatabase: repository list room 에 저장
  RepoDatabase ->> RepoRepository: room repository list
  RepoRepository ->> ViewModel: pagingData

```