### PR TITLE
feat: Detail 화면에서 Star State 및 Star Count 를 Room 과 동기화

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -1,31 +1,26 @@
 package com.prac.githubrepo.main
 
-import android.util.SparseArray
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import androidx.paging.map
 import com.prac.data.entity.RepoEntity
-import com.prac.data.exception.GitHubApiException
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val repoRepository: RepoRepository
+    private val repoRepository: RepoRepository,
+    private val backOffWorkManager: BackOffWorkManager
 ): ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -62,6 +57,16 @@ class MainViewModel @Inject constructor(
             repoRepository.starLocalRepository(repoEntity.id, repoEntity.stargazersCount + 1)
 
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 
@@ -70,6 +75,16 @@ class MainViewModel @Inject constructor(
             repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount - 1)
 
             repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addUnStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -60,7 +60,10 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoEntity.id}",
+                                work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message
@@ -78,7 +81,10 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoEntity.id}",
+                                work = { repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -60,7 +60,7 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message
@@ -78,7 +78,7 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addUnStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
@@ -1,5 +1,14 @@
 package com.prac.githubrepo.main.backoff
 
 interface BackOffWorkManager {
+    fun addWork(
+        uniqueID: String,
+        times: Int = Int.MAX_VALUE,
+        initialDelay: Long = 1_000, // 1 second
+        maxDelay: Long = 100_000,// 100 second
+        factor: Double = 2.0,
+        work: suspend () -> Result<*>
+    )
+
     fun clearWork()
 }

--- a/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
@@ -1,0 +1,9 @@
+package com.prac.githubrepo.main.backoff
+
+interface BackOffWorkManager {
+    suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
+
+    suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
+
+    fun clearWork()
+}

--- a/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
@@ -1,9 +1,5 @@
 package com.prac.githubrepo.main.backoff
 
 interface BackOffWorkManager {
-    suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
-
-    suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
-
     fun clearWork()
 }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -4,19 +4,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class DetailViewModel @Inject constructor(
-    private val repoRepository: RepoRepository
+    private val repoRepository: RepoRepository,
+    private val backOffWorkManager: BackOffWorkManager
 ) : ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -82,6 +84,16 @@ class DetailViewModel @Inject constructor(
             repoRepository.starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount + 1)
 
             repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 
@@ -90,6 +102,16 @@ class DetailViewModel @Inject constructor(
             repoRepository.unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount - 1)
 
             repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addUnStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -87,7 +87,7 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message
@@ -105,7 +105,7 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addUnStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -87,7 +87,10 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoDetailEntity.id}",
+                                work = { repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message
@@ -105,7 +108,10 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoDetailEntity.id}",
+                                work = { repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -20,9 +20,7 @@ import kotlin.math.pow
 class BackOffModule {
     @Provides
     @Singleton
-    fun provideBackOffWorkManager(
-        repoRepository: RepoRepository
-    ) : BackOffWorkManager {
+    fun provideBackOffWorkManager() : BackOffWorkManager {
         return object : BackOffWorkManager {
             private val _workMap = mutableMapOf<Int, Job>()
 
@@ -32,35 +30,6 @@ class BackOffModule {
             private val multiplier = 2.0
             private val secondsToMillis = 1000
 
-            override suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
-                _workMap[uniqueID]?.cancel()
-
-                val job = coroutineScope.launch {
-                    repeat(attemptTimes) { attemptTime ->
-                        delay(calculateExponentialBackOffDelay(attemptTime))
-
-                        repoRepository.starRepository(userName, repoName)
-                            .onSuccess { _workMap[uniqueID]?.cancel() }
-                    }
-                }
-
-                _workMap[uniqueID] = job
-            }
-
-            override suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
-                _workMap[uniqueID]?.cancel()
-
-                val job = coroutineScope.launch {
-                    repeat(attemptTimes) { attemptTime ->
-                        delay(calculateExponentialBackOffDelay(attemptTime))
-
-                        repoRepository.unStarRepository(userName, repoName)
-                            .onSuccess { _workMap[uniqueID]?.cancel() }
-                    }
-                }
-
-                _workMap[uniqueID] = job
-            }
 
             override fun clearWork() {
                 _workMap.forEach { if (!it.value.isCompleted) it.value.cancel() }

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
+import kotlin.math.pow
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -41,6 +42,8 @@ class BackOffModule {
                 TODO("Not yet implemented")
             }
 
+            private fun calculateExponentialBackOffDelay(attemptTime: Int) : Long =
+                multiplier.pow(attemptTime).toLong() * secondsToMillis
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -63,7 +63,9 @@ class BackOffModule {
             }
 
             override fun clearWork() {
-                TODO("Not yet implemented")
+                _workMap.forEach { if (!it.value.isCompleted) it.value.cancel() }
+
+                _workMap.clear()
             }
 
             private fun calculateExponentialBackOffDelay(attemptTime: Int) : Long =

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -1,0 +1,46 @@
+package com.prac.githubrepo.main.di
+
+import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class BackOffModule {
+    @Provides
+    @Singleton
+    fun provideBackOffWorkManager(
+        repoRepository: RepoRepository
+    ) : BackOffWorkManager {
+        return object : BackOffWorkManager {
+            private val _workMap = mutableMapOf<Int, Job>()
+
+            private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+            private val attemptTimes = 8
+            private val multiplier = 2.0
+            private val secondsToMillis = 1000
+
+            override suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
+                TODO("Not yet implemented")
+            }
+
+            override fun clearWork() {
+                TODO("Not yet implemented")
+            }
+
+        }
+    }
+}

--- a/data/src/main/java/com/prac/data/repository/RepoRepository.kt
+++ b/data/src/main/java/com/prac/data/repository/RepoRepository.kt
@@ -14,6 +14,8 @@ abstract class RepoRepository : RemoteMediator<Int, Repository>() {
 
     abstract suspend fun getRepository(userName: String, repoName: String) : Result<RepoDetailEntity>
 
+    abstract suspend fun getStarStateAndStarCount(id: Int) : Flow<Pair<Boolean?, Int?>>
+
     abstract suspend fun isStarred(id: Int, repoName: String)
 
     abstract suspend fun starRepository(userName: String, repoName: String) : Result<Unit>

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -59,6 +59,10 @@ internal class RepoRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun getStarStateAndStarCount(id: Int): Flow<Pair<Boolean?, Int?>> {
+        return repositoryDatabase.repositoryDao().getRepository(id).map { Pair(it?.isStarred, it?.stargazersCount) }
+    }
+
     override suspend fun isStarred(id: Int, repoName: String) {
         val result = repoStarApiDataSource.checkRepositoryIsStarred(repoName)
 

--- a/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
+++ b/data/src/main/java/com/prac/data/repository/impl/RepoRepositoryImpl.kt
@@ -49,6 +49,9 @@ internal class RepoRepositoryImpl @Inject constructor(
         return try {
             val model = repoApiDataSource.getRepository(userName, repoName)
 
+            // 디테일 화면에 들어오는 동안 Star Count 가 변경될 수 있기 때문에 Star Count update
+            repositoryDatabase.repositoryDao().updateStarCount(model.id, model.stargazersCount)
+
             Result.success(
                 RepoDetailEntity(
                     model.id, model.name, OwnerEntity(model.owner.login, model.owner.avatarUrl), model.stargazersCount, model.forksCount, null

--- a/data/src/main/java/com/prac/data/source/local/room/dao/RepositoryDao.kt
+++ b/data/src/main/java/com/prac/data/source/local/room/dao/RepositoryDao.kt
@@ -7,11 +7,15 @@ import androidx.room.OnConflictStrategy
 import androidx.room.Query
 import androidx.room.Update
 import com.prac.data.source.local.room.entity.Repository
+import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface RepositoryDao {
     @Query("SELECT * FROM repository")
     fun getRepositories(): PagingSource<Int, Repository>
+
+    @Query("SELECT * FROM repository WHERE id = :id")
+    fun getRepository(id: Int): Flow<Repository?>
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     suspend fun insertRepositories(repos: List<Repository>)


### PR DESCRIPTION
notion - https://www.notion.so/feat-Detail-Star-State-Star-Count-Room-102a26591b6180e98538c0d60007af6e?pvs=4

# AS-IS

- 기존에 존재했던 `StarStateMediator` 를 제거함으로써 Detail 화면에서 Star State 를 반영하고 있지 않다.
- Detail 화면에서 Star 및 unStar 를 눌렀을 때 Room 에 Star State 와 Star Count 를 동기화하고 있지 않다.

# TO-BE

```kotlin
@Query("SELECT * FROM repository WHERE id = :id")
fun getRepository(id: Int): Flow<Repository?>
```

- DAO 에 Repository 를 불러오는 메서드 추가

```kotlin
suspend fun getStarStateAndStarCount(id: Int): Flow<Pair<Boolean?, Int?>> {
    return repositoryDatabase.repositoryDao().getRepository(id).map { Pair(it?.isStarred, it?.stargazersCount) }
}
```

- RepoRepository 구현체에서 map 함수를 통해 Pair 로 변경하는 메서드 추가

```kotlin
repoRepository.getStarStateAndStarCount(repoDetailEntity.id).collect { pair ->
    val isStarred = pair.first
    val stargazersCount = pair.second

    // Room 에서 repoDetailEntity.id 값이 없을 경우에 null 을 반환한다.
    if (stargazersCount == null) {
        // update uiState to Error
    }

    // List 화면에서 Star Check 가 완료되기 전에 사용자가 Detail 화면으로 넘어온 경우 null 을 반환한다.
    if (isStarred == null) {
        // repository is starred api call
    }

    _uiState.update { .... }
}
```

- Get Repository Api 성공 시 Room 에 저장된 Repository 의 Star State 및 Star Count 동기화

- #86 