### PR TITLE
feat: Star 및 UnStar Api call 실패 시 Exponential BackOff 적용

### DIFF
--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -1,31 +1,26 @@
 package com.prac.githubrepo.main
 
-import android.util.SparseArray
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.paging.LoadState
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
-import androidx.paging.map
 import com.prac.data.entity.RepoEntity
-import com.prac.data.exception.GitHubApiException
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.scan
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class MainViewModel @Inject constructor(
-    private val repoRepository: RepoRepository
+    private val repoRepository: RepoRepository,
+    private val backOffWorkManager: BackOffWorkManager
 ): ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -62,6 +57,16 @@ class MainViewModel @Inject constructor(
             repoRepository.starLocalRepository(repoEntity.id, repoEntity.stargazersCount + 1)
 
             repoRepository.starRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 
@@ -70,6 +75,16 @@ class MainViewModel @Inject constructor(
             repoRepository.unStarLocalRepository(repoEntity.id, repoEntity.stargazersCount - 1)
 
             repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addUnStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -60,7 +60,10 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoEntity.id}",
+                                work = { repoRepository.starRepository(repoEntity.owner.login, repoEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message
@@ -78,7 +81,10 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoEntity.id}",
+                                work = { repoRepository.unStarRepository(repoEntity.owner.login, repoEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/MainViewModel.kt
@@ -60,7 +60,7 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message
@@ -78,7 +78,7 @@ class MainViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addUnStarWorkWithUniqueID(repoEntity.id, repoEntity.owner.login, repoEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
@@ -1,5 +1,14 @@
 package com.prac.githubrepo.main.backoff
 
 interface BackOffWorkManager {
+    fun addWork(
+        uniqueID: String,
+        times: Int = Int.MAX_VALUE,
+        initialDelay: Long = 1_000, // 1 second
+        maxDelay: Long = 100_000,// 100 second
+        factor: Double = 2.0,
+        work: suspend () -> Result<*>
+    )
+
     fun clearWork()
 }

--- a/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
@@ -1,0 +1,9 @@
+package com.prac.githubrepo.main.backoff
+
+interface BackOffWorkManager {
+    suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
+
+    suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
+
+    fun clearWork()
+}

--- a/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/backoff/BackOffWorkManager.kt
@@ -1,9 +1,5 @@
 package com.prac.githubrepo.main.backoff
 
 interface BackOffWorkManager {
-    suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
-
-    suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)
-
     fun clearWork()
 }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -4,19 +4,21 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.prac.data.entity.RepoDetailEntity
 import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.backoff.BackOffWorkManager
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class DetailViewModel @Inject constructor(
-    private val repoRepository: RepoRepository
+    private val repoRepository: RepoRepository,
+    private val backOffWorkManager: BackOffWorkManager
 ) : ViewModel() {
     sealed class UiState {
         data object Idle : UiState()
@@ -82,6 +84,16 @@ class DetailViewModel @Inject constructor(
             repoRepository.starLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount + 1)
 
             repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 
@@ -90,6 +102,16 @@ class DetailViewModel @Inject constructor(
             repoRepository.unStarLocalRepository(repoDetailEntity.id, repoDetailEntity.stargazersCount - 1)
 
             repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name)
+                .onFailure {
+                    when (it) {
+                        is IOException -> {
+                            backOffWorkManager.addUnStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+                        }
+                        else -> {
+                            // TODO Show Error Message
+                        }
+                    }
+                }
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -87,7 +87,7 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message
@@ -105,7 +105,7 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-                            backOffWorkManager.addUnStarWorkWithUniqueID(repoDetailEntity.id, repoDetailEntity.owner.login, repoDetailEntity.name)
+
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/detail/DetailViewModel.kt
@@ -87,7 +87,10 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoDetailEntity.id}",
+                                work = { repoRepository.starRepository(repoDetailEntity.owner.login, repoDetailEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message
@@ -105,7 +108,10 @@ class DetailViewModel @Inject constructor(
                 .onFailure {
                     when (it) {
                         is IOException -> {
-
+                            backOffWorkManager.addWork(
+                                uniqueID = "star_${repoDetailEntity.id}",
+                                work = { repoRepository.unStarRepository(repoDetailEntity.owner.login, repoDetailEntity.name) }
+                            )
                         }
                         else -> {
                             // TODO Show Error Message

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -20,9 +20,7 @@ import kotlin.math.pow
 class BackOffModule {
     @Provides
     @Singleton
-    fun provideBackOffWorkManager(
-        repoRepository: RepoRepository
-    ) : BackOffWorkManager {
+    fun provideBackOffWorkManager() : BackOffWorkManager {
         return object : BackOffWorkManager {
             private val _workMap = mutableMapOf<Int, Job>()
 
@@ -32,35 +30,6 @@ class BackOffModule {
             private val multiplier = 2.0
             private val secondsToMillis = 1000
 
-            override suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
-                _workMap[uniqueID]?.cancel()
-
-                val job = coroutineScope.launch {
-                    repeat(attemptTimes) { attemptTime ->
-                        delay(calculateExponentialBackOffDelay(attemptTime))
-
-                        repoRepository.starRepository(userName, repoName)
-                            .onSuccess { _workMap[uniqueID]?.cancel() }
-                    }
-                }
-
-                _workMap[uniqueID] = job
-            }
-
-            override suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
-                _workMap[uniqueID]?.cancel()
-
-                val job = coroutineScope.launch {
-                    repeat(attemptTimes) { attemptTime ->
-                        delay(calculateExponentialBackOffDelay(attemptTime))
-
-                        repoRepository.unStarRepository(userName, repoName)
-                            .onSuccess { _workMap[uniqueID]?.cancel() }
-                    }
-                }
-
-                _workMap[uniqueID] = job
-            }
 
             override fun clearWork() {
                 _workMap.forEach { if (!it.value.isCompleted) it.value.cancel() }

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import javax.inject.Singleton
+import kotlin.math.pow
 
 @Module
 @InstallIn(SingletonComponent::class)
@@ -41,6 +42,8 @@ class BackOffModule {
                 TODO("Not yet implemented")
             }
 
+            private fun calculateExponentialBackOffDelay(attemptTime: Int) : Long =
+                multiplier.pow(attemptTime).toLong() * secondsToMillis
         }
     }
 }

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -63,7 +63,9 @@ class BackOffModule {
             }
 
             override fun clearWork() {
-                TODO("Not yet implemented")
+                _workMap.forEach { if (!it.value.isCompleted) it.value.cancel() }
+
+                _workMap.clear()
             }
 
             private fun calculateExponentialBackOffDelay(attemptTime: Int) : Long =

--- a/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
+++ b/app/src/main/java/com/prac/githubrepo/main/di/BackOffModule.kt
@@ -1,0 +1,46 @@
+package com.prac.githubrepo.main.di
+
+import com.prac.data.repository.RepoRepository
+import com.prac.githubrepo.main.backoff.BackOffWorkManager
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class BackOffModule {
+    @Provides
+    @Singleton
+    fun provideBackOffWorkManager(
+        repoRepository: RepoRepository
+    ) : BackOffWorkManager {
+        return object : BackOffWorkManager {
+            private val _workMap = mutableMapOf<Int, Job>()
+
+            private val coroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+
+            private val attemptTimes = 8
+            private val multiplier = 2.0
+            private val secondsToMillis = 1000
+
+            override suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
+                TODO("Not yet implemented")
+            }
+
+            override suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String) {
+                TODO("Not yet implemented")
+            }
+
+            override fun clearWork() {
+                TODO("Not yet implemented")
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
notion - https://www.notion.so/feat-Star-UnStar-Api-call-Exponential-BackOff-102a26591b6180379af9c4f78a8106cd?pvs=4

# AS-IS

- 현재 Star 및 UnStar Api call 실패 시 Exponential BackOff 가 적용되어 있지 않다.

# TO-BE

```kotlin
interface BackOffWorkManager {
    suspend fun addStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)

    suspend fun addUnStarWorkWithUniqueID(uniqueID: Int, userName: String, repoName: String)

    fun clearWork()
}
```

- MainViewModel 과 DetailViewModel 에서 같이 사용할 BackOffWorkManager 인터페이스 추가

- Star, UnStar Api call 실패 시 BackOffWorkManager 를 통해 작업을 추가하는 로직 추가